### PR TITLE
Default to follow mode when using agent

### DIFF
--- a/crates/agent_ui/src/acp/thread_view/active_thread.rs
+++ b/crates/agent_ui/src/acp/thread_view/active_thread.rs
@@ -371,7 +371,7 @@ impl AcpThreadView {
             plan_expanded: false,
             queue_expanded: true,
             editor_expanded: false,
-            should_be_following: false,
+            should_be_following: true,
             editing_message: None,
             local_queued_messages: Vec::new(),
             queued_message_editors: Vec::new(),


### PR DESCRIPTION
Change should_be_following from false to true in AcpThreadView::new so the editor automatically follows agent activity by default.

Spec-Ref: helix-specs@3e1016f73:001315_in-zed-lets-default-to