### PR TITLE
Add suggest_dev_container setting to disable dev container suggestions

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1088,7 +1088,7 @@
     // Whether to automatically open the agent panel when Zed launches.
     //
     // Default: false
-    "auto_open_panel": false
+    "auto_open_panel": false,
   },
   // Whether the screen sharing icon is shown in the os status bar.
   "show_call_status_icon": true,
@@ -2412,6 +2412,9 @@
   "ssh_connections": [],
   // Whether to read ~/.ssh/config for ssh connection sources.
   "read_ssh_config": true,
+  // Whether to show a notification suggesting to open the project in a dev container
+  // when a `.devcontainer` directory is detected.
+  "suggest_dev_container": true,
   // Default timeout in seconds for all context server tool calls.
   // Individual servers can override this in their configuration.
   // Examples:

--- a/crates/recent_projects/src/dev_container_suggest.rs
+++ b/crates/recent_projects/src/dev_container_suggest.rs
@@ -1,6 +1,7 @@
 use db::kvp::KEY_VALUE_STORE;
 use gpui::{SharedString, Window};
 use project::{Project, WorktreeId};
+use settings::Settings;
 use std::sync::LazyLock;
 use ui::prelude::*;
 use util::rel_path::RelPath;
@@ -8,6 +9,8 @@ use workspace::Workspace;
 use workspace::notifications::NotificationId;
 use workspace::notifications::simple_message_notification::MessageNotification;
 use worktree::UpdatedEntriesSet;
+
+use crate::RemoteSettings;
 
 const DEV_CONTAINER_SUGGEST_KEY: &str = "dev_container_suggest_dismissed";
 
@@ -28,6 +31,11 @@ pub fn suggest_on_worktree_updated(
     window: &mut Window,
     cx: &mut Context<Workspace>,
 ) {
+    // Check if dev container suggestions are enabled
+    if !RemoteSettings::get_global(cx).suggest_dev_container {
+        return;
+    }
+
     let devcontainer_updated = updated_entries
         .iter()
         .any(|(path, _, _)| path.as_ref() == devcontainer_path());

--- a/crates/recent_projects/src/remote_connections.rs
+++ b/crates/recent_projects/src/remote_connections.rs
@@ -32,6 +32,9 @@ pub struct RemoteSettings {
     pub wsl_connections: ExtendingVec<WslConnection>,
     /// Whether to read ~/.ssh/config for ssh connection sources.
     pub read_ssh_config: bool,
+    /// Whether to show a notification suggesting to open the project in a dev container
+    /// when a `.devcontainer` directory is detected.
+    pub suggest_dev_container: bool,
 }
 
 impl RemoteSettings {
@@ -119,6 +122,7 @@ impl Settings for RemoteSettings {
             ssh_connections: remote.ssh_connections.clone().unwrap_or_default().into(),
             wsl_connections: remote.wsl_connections.clone().unwrap_or_default().into(),
             read_ssh_config: remote.read_ssh_config.unwrap(),
+            suggest_dev_container: remote.suggest_dev_container.unwrap_or(true),
         }
     }
 }

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -1020,6 +1020,11 @@ pub struct RemoteSettingsContent {
     pub dev_container_connections: Option<Vec<DevContainerConnection>>,
     pub read_ssh_config: Option<bool>,
     pub use_podman: Option<bool>,
+    /// Whether to show a notification suggesting to open the project in a dev container
+    /// when a `.devcontainer` directory is detected.
+    ///
+    /// Default: true
+    pub suggest_dev_container: Option<bool>,
 }
 
 #[with_fallible_options]


### PR DESCRIPTION
Adds a new setting `remote.suggest_dev_container` (default: true) that controls whether a notification is shown suggesting to open the project in a dev container when a .devcontainer directory is detected.

When set to false, the notification is suppressed. This is useful for platforms like Helix that run Zed inside their own managed containers.

Changes:
- Added suggest_dev_container field to RemoteSettingsContent schema
- Added check in suggest_on_worktree_updated() to respect the setting
- Added suggest_dev_container to RemoteSettings struct
- Added default value in default.json

Spec-Ref: helix-specs@de1a8873b:001318_in-zed-do-not-offer-to