### PR TITLE
fix: adapt to upstream connect() API change

### DIFF
--- a/crates/external_websocket_sync/src/external_websocket_sync.rs
+++ b/crates/external_websocket_sync/src/external_websocket_sync.rs
@@ -5,13 +5,11 @@
 //! and integration with AI platforms and other external tools.
 
 use anyhow::{Context, Result};
-use util::ResultExt;
 use assistant_text_thread::{TextThread, TextThreadId, TextThreadStore, MessageId};
 use assistant_slash_command::SlashCommandWorkingSet;
 use clock::ReplicaId;
 use collections::HashMap;
-use futures::StreamExt;
-use gpui::{App, AsyncApp, Entity, EventEmitter, Global, Subscription, Task};
+use gpui::{App, Entity, EventEmitter, Global, Subscription, Task};
 use tokio::sync::mpsc;
 
 use language_model;
@@ -21,8 +19,6 @@ use prompt_store::PromptBuilder;
 use serde::{Deserialize, Serialize};
 use session::AppSession;
 use std::sync::Arc;
-
-use settings::{Settings, SettingsStore};
 
 mod websocket_sync;
 
@@ -774,8 +770,8 @@ pub fn init_full(
 
 /// Initialize with session and prompt builder, store for later use
 pub async fn init_with_session(
-    session: Arc<AppSession>,
-    prompt_builder: Arc<PromptBuilder>,
+    _session: Arc<AppSession>,
+    _prompt_builder: Arc<PromptBuilder>,
 ) -> Result<()> {
     log::info!("Session and prompt builder will be passed directly to initialization methods");
     Ok(())

--- a/crates/external_websocket_sync/src/mcp.rs
+++ b/crates/external_websocket_sync/src/mcp.rs
@@ -2,7 +2,6 @@
 
 use anyhow::{Context, Result};
 use collections::HashMap;
-use futures::{SinkExt, StreamExt};
 use gpui::{App, Task};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -5,11 +5,10 @@
 
 use anyhow::Result;
 use acp_thread::{AcpThread, AcpThreadEvent};
-use action_log::ActionLog;
 use agent::ThreadStore;
 use acp_thread::AgentSessionInfo;
-use agent_client_protocol::{ContentBlock, PromptCapabilities, SessionId, TextContent};
-use gpui::{App, Entity, EventEmitter, WeakEntity, prelude::*};
+use agent_client_protocol::{ContentBlock, TextContent};
+use gpui::{App, Entity, WeakEntity};
 use parking_lot::RwLock;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -18,8 +17,6 @@ use fs::Fs;
 use project::Project;
 use tokio::sync::mpsc;
 use util::ResultExt;
-use watch;
-
 use settings::Settings as _;
 use crate::{ExternalAgent, ThreadCreationRequest, ThreadOpenRequest, SyncEvent};
 
@@ -554,13 +551,13 @@ fn create_new_thread_sync(
     );
 
     // Connect to get AgentConnection
-    let connection_task = server.connect(None, delegate, cx);
+    let connection_task = server.connect(delegate, cx);
 
     // Spawn async task to complete the connection and create the thread
     let request_clone = request.clone();
     let project_clone = project.clone();
     cx.spawn(async move |cx| {
-        let (connection, _spawn_task) = connection_task
+        let (connection, _spawn_task): (std::rc::Rc<dyn acp_thread::AgentConnection>, _) = connection_task
             .await
             .log_err()
             .ok_or_else(|| anyhow::anyhow!("Failed to connect to agent"))?;
@@ -949,7 +946,7 @@ async fn load_thread_from_agent(
             None,
             None,
         );
-        let connection_task = server.connect(None, delegate, cx);
+        let connection_task = server.connect(delegate, cx);
         // Use ZED_WORK_DIR for consistency with session storage
         let cwd = std::env::var("ZED_WORK_DIR")
             .ok()
@@ -1132,7 +1129,7 @@ fn open_existing_thread_sync(
     );
 
     // Connect to get AgentConnection
-    let connection_task = server.connect(None, delegate, cx);
+    let connection_task = server.connect(delegate, cx);
 
     // Use ZED_WORK_DIR for consistency with session storage
     let cwd = std::env::var("ZED_WORK_DIR")


### PR DESCRIPTION
## Summary
- Upstream PR #50093 removed the `root_dir` parameter from `AgentServer::connect()`
- Updated 3 call sites in `external_websocket_sync` crate to match new 2-arg signature
- Cleaned up unused imports that surfaced after the upstream merge

## Test plan
- [x] `cargo check -p external_websocket_sync` passes (0 errors, only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)