### PR TITLE
fix: wire up auto_open_panel to AgentPanel starts_open()

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -2094,6 +2094,10 @@ impl Panel for AgentPanel {
         AGENT_PANEL_KEY
     }
 
+    fn starts_open(&self, _window: &Window, cx: &App) -> bool {
+        AgentSettings::get_global(cx).auto_open_panel
+    }
+
     fn position(&self, _window: &Window, cx: &App) -> DockPosition {
         agent_panel_dock_position(cx)
     }


### PR DESCRIPTION
## Summary
- The `auto_open_panel` agent setting existed but was never wired to `Panel::starts_open()`
- Default `starts_open()` returns `false`, so the agent panel never auto-opened in fresh containers
- This adds a 4-line override that checks `AgentSettings::get_global(cx).auto_open_panel`

## Context
Fresh spectask containers have `"auto_open_panel": true` in settings but no saved workspace state, so the panel stayed closed on boot.

## Test plan
- [x] Syntactically correct (follows same pattern as ProjectPanel's `starts_open`)
- [ ] Needs Zed rebuild + deploy to verify visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)