### PR TITLE
fix: disable migration banner in Helix builds

### DIFF
--- a/crates/zed/src/zed/migrate.rs
+++ b/crates/zed/src/zed/migrate.rs
@@ -147,6 +147,12 @@ impl ToolbarItemView for MigrationBanner {
     ) -> ToolbarItemLocation {
         self.reset(cx);
 
+        // In Helix builds, settings are managed by the settings-sync-daemon.
+        // Don't prompt users to migrate settings that will be overwritten.
+        if cfg!(feature = "external_websocket_sync") {
+            return ToolbarItemLocation::Hidden;
+        }
+
         let Some(target) = active_pane_item
             .and_then(|item| item.act_as::<Editor>(cx))
             .and_then(|editor| editor.update(cx, |editor, cx| editor.target_file_abs_path(cx)))


### PR DESCRIPTION
## Summary
- Skip the settings migration banner entirely when `external_websocket_sync` feature is enabled
- In Helix builds, `settings.json` is managed by the settings-sync-daemon, so prompting users to migrate deprecated settings is misleading (changes would be overwritten on next sync)

## Test plan
- [ ] Build Zed with `external_websocket_sync` feature (`./stack build-zed release`)
- [ ] Open settings.json in Zed — no migration banner should appear
- [ ] Verify migration banner still works in non-Helix Zed builds (standard feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)