### PR TITLE
Prevent keyboard focus stealing when following agent

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5046,8 +5046,11 @@ impl Workspace {
         }
 
         // if you're already following, find the right pane and focus it.
+        // For Agent following, we only track visually without stealing keyboard focus.
         if let Some(follower_state) = self.follower_states.get(&leader_id) {
-            window.focus(&follower_state.pane().focus_handle(cx), cx);
+            if !matches!(leader_id, CollaboratorId::Agent) {
+                window.focus(&follower_state.pane().focus_handle(cx), cx);
+            }
 
             return;
         }
@@ -5683,7 +5686,10 @@ impl Workspace {
         }
 
         pane.update(cx, |pane, cx| {
-            let focus_active_item = pane.has_focus(window, cx) || transfer_focus;
+            // For Agent following, never steal keyboard focus - only update visual state.
+            // Users can click to explicitly focus the editor if they want to.
+            let focus_active_item = !matches!(leader_id, CollaboratorId::Agent)
+                && (pane.has_focus(window, cx) || transfer_focus);
             if let Some(index) = pane.index_for_item(item.as_ref()) {
                 pane.activate_item(index, false, false, window, cx);
             } else {


### PR DESCRIPTION
When 'follow agent' is active, the editor would steal keyboard focus from the prompt input whenever the agent opened or navigated to a file. This caused user keystrokes to be typed into source files instead of the prompt.

Fix: Skip focus transfer for CollaboratorId::Agent in both follow() and leader_updated(). Visual tracking (showing what the agent is doing) still works; only keyboard focus transfer is disabled.

Users can still click the editor to explicitly take focus when desired.

Spec-Ref: helix-specs@b31a09c9e:001399_in-zed-often-the

Closes #ISSUE

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [ ] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A *or* Added/Fixed/Improved ...
