### PR TITLE
fix: wait for MCP tools and select model before sending first WebSocket message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ crates/docs_preprocessor/actions.json
 # Local documentation audit files
 /december-2025-releases.md
 /docs/december-2025-documentation-gaps.md
+/target-ubuntu22
+/target-ubuntu25

--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -151,6 +151,15 @@ pub trait AgentConnection {
         None
     }
 
+    /// Wait for MCP context server tools to finish loading.
+    ///
+    /// Default implementation returns immediately. Agents that load tools
+    /// asynchronously (e.g. via MCP ListTools RPC) should override this to
+    /// block until all pending tool loads have completed.
+    fn wait_for_tools_ready(&self, _cx: &mut App) -> Task<()> {
+        Task::ready(())
+    }
+
     fn into_any(self: Rc<Self>) -> Rc<dyn Any>;
 }
 

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1433,26 +1433,41 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
     fn wait_for_tools_ready(&self, cx: &mut App) -> Task<()> {
         let agent = self.0.read(cx);
         let registry = agent.context_server_registry().read(cx);
-        if !registry.has_pending_tool_loads() {
+        let has_pending = registry.has_pending_tool_loads();
+
+        let context_server_store = agent.project.read(cx).context_server_store();
+        let store = context_server_store.read(cx);
+        let configured_server_count = store.configured_server_ids().len();
+        let registered_count = registry.registered_server_count();
+        let has_unregistered_servers =
+            configured_server_count > 0 && registered_count < configured_server_count;
+
+        if !has_pending && !has_unregistered_servers {
             return Task::ready(());
         }
+
         let mut receiver = registry.tools_ready_receiver();
-        cx.spawn(async move |_cx| {
+        let expected_servers = configured_server_count;
+        let registry_handle = agent.context_server_registry().clone();
+        cx.spawn(async move |cx| {
             let wait = async {
                 loop {
                     if receiver.changed().await.is_err() {
                         return;
                     }
-                    if *receiver.borrow() == 0 {
+                    let all_done = cx.update(|cx| {
+                        let reg = registry_handle.read(cx);
+                        !reg.has_pending_tool_loads()
+                            && reg.registered_server_count() >= expected_servers
+                    });
+                    if all_done {
                         return;
                     }
                 }
             };
             let timeout = async {
                 smol::Timer::after(std::time::Duration::from_secs(30)).await;
-                log::warn!(
-                    "Timed out waiting for MCP tools to load after 30 seconds, proceeding without them"
-                );
+                log::warn!("Timed out waiting for MCP tools to load (30s), proceeding without them");
             };
             futures::future::select(Box::pin(wait), Box::pin(timeout)).await;
         })

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -338,6 +338,10 @@ impl NativeAgent {
         self.register_session(thread, cx)
     }
 
+    pub fn context_server_registry(&self) -> &Entity<ContextServerRegistry> {
+        &self.context_server_registry
+    }
+
     fn register_session(
         &mut self,
         thread_handle: Entity<Thread>,
@@ -1424,6 +1428,34 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
 
     fn telemetry(&self) -> Option<Rc<dyn acp_thread::AgentTelemetry>> {
         Some(Rc::new(self.clone()) as Rc<dyn acp_thread::AgentTelemetry>)
+    }
+
+    fn wait_for_tools_ready(&self, cx: &mut App) -> Task<()> {
+        let agent = self.0.read(cx);
+        let registry = agent.context_server_registry().read(cx);
+        if !registry.has_pending_tool_loads() {
+            return Task::ready(());
+        }
+        let mut receiver = registry.tools_ready_receiver();
+        cx.spawn(async move |_cx| {
+            let wait = async {
+                loop {
+                    if receiver.changed().await.is_err() {
+                        return;
+                    }
+                    if *receiver.borrow() == 0 {
+                        return;
+                    }
+                }
+            };
+            let timeout = async {
+                smol::Timer::after(std::time::Duration::from_secs(30)).await;
+                log::warn!(
+                    "Timed out waiting for MCP tools to load after 30 seconds, proceeding without them"
+                );
+            };
+            futures::future::select(Box::pin(wait), Box::pin(timeout)).await;
+        })
     }
 
     fn into_any(self: Rc<Self>) -> Rc<dyn Any> {

--- a/crates/agent/src/tools/context_server_registry.rs
+++ b/crates/agent/src/tools/context_server_registry.rs
@@ -88,6 +88,10 @@ impl ContextServerRegistry {
         self.pending_tool_loads > 0
     }
 
+    pub fn registered_server_count(&self) -> usize {
+        self.registered_servers.len()
+    }
+
     pub fn tools_ready_receiver(&self) -> watch::Receiver<usize> {
         self.tools_ready_tx.receiver()
     }

--- a/crates/agent/src/tools/context_server_registry.rs
+++ b/crates/agent/src/tools/context_server_registry.rs
@@ -1,7 +1,7 @@
 use crate::{AgentToolOutput, AnyAgentTool, ToolCallEventStream, ToolInput};
 use agent_client_protocol::ToolKind;
 use anyhow::Result;
-use collections::{BTreeMap, HashMap};
+use collections::{BTreeMap, HashMap, HashSet};
 use context_server::{ContextServerId, client::NotificationSubscription};
 use futures::FutureExt as _;
 use gpui::{App, AppContext, AsyncApp, Context, Entity, EventEmitter, SharedString, Task};
@@ -32,6 +32,7 @@ pub struct ContextServerRegistry {
     server_store: Entity<ContextServerStore>,
     registered_servers: HashMap<ContextServerId, RegisteredContextServer>,
     pending_tool_loads: usize,
+    pending_server_starts: HashSet<ContextServerId>,
     tools_ready_tx: watch::Sender<usize>,
     _subscription: gpui::Subscription,
 }
@@ -51,13 +52,35 @@ impl ContextServerRegistry {
             server_store: server_store.clone(),
             registered_servers: HashMap::default(),
             pending_tool_loads: 0,
+            pending_server_starts: HashSet::default(),
             tools_ready_tx,
             _subscription: cx.subscribe(&server_store, Self::handle_context_server_store_event),
         };
-        for server in server_store.read(cx).running_servers() {
+        let (running_servers, starting_server_ids) = {
+            let store = server_store.read(cx);
+            let running = store.running_servers();
+            let starting: Vec<_> = store
+                .server_ids()
+                .iter()
+                .filter(|id| {
+                    matches!(
+                        store.status_for_server(id),
+                        Some(ContextServerStatus::Starting)
+                    )
+                })
+                .cloned()
+                .collect();
+            (running, starting)
+        };
+        for server in running_servers {
             this.reload_tools_for_server(server.id(), cx);
             this.reload_prompts_for_server(server.id(), cx);
         }
+        for server_id in starting_server_ids {
+            this.pending_server_starts.insert(server_id);
+            this.pending_tool_loads += 1;
+        }
+        let _ = this.tools_ready_tx.send(this.pending_tool_loads);
         this
     }
 
@@ -276,10 +299,18 @@ impl ContextServerRegistry {
         match status {
             ContextServerStatus::Starting => {}
             ContextServerStatus::Running => {
+                if self.pending_server_starts.remove(server_id) {
+                    self.pending_tool_loads = self.pending_tool_loads.saturating_sub(1);
+                    let _ = self.tools_ready_tx.send(self.pending_tool_loads);
+                }
                 self.reload_tools_for_server(server_id.clone(), cx);
                 self.reload_prompts_for_server(server_id.clone(), cx);
             }
             ContextServerStatus::Stopped | ContextServerStatus::Error(_) => {
+                if self.pending_server_starts.remove(server_id) {
+                    self.pending_tool_loads = self.pending_tool_loads.saturating_sub(1);
+                    let _ = self.tools_ready_tx.send(self.pending_tool_loads);
+                }
                 if let Some(registered_server) = self.registered_servers.remove(server_id) {
                     if !registered_server.tools.is_empty() {
                         cx.emit(ContextServerRegistryEvent::ToolsChanged);

--- a/crates/agent/src/tools/context_server_registry.rs
+++ b/crates/agent/src/tools/context_server_registry.rs
@@ -31,6 +31,8 @@ impl EventEmitter<ContextServerRegistryEvent> for ContextServerRegistry {}
 pub struct ContextServerRegistry {
     server_store: Entity<ContextServerStore>,
     registered_servers: HashMap<ContextServerId, RegisteredContextServer>,
+    pending_tool_loads: usize,
+    tools_ready_tx: watch::Sender<usize>,
     _subscription: gpui::Subscription,
 }
 
@@ -44,9 +46,12 @@ struct RegisteredContextServer {
 
 impl ContextServerRegistry {
     pub fn new(server_store: Entity<ContextServerStore>, cx: &mut Context<Self>) -> Self {
+        let (tools_ready_tx, _) = watch::channel(0usize);
         let mut this = Self {
             server_store: server_store.clone(),
             registered_servers: HashMap::default(),
+            pending_tool_loads: 0,
+            tools_ready_tx,
             _subscription: cx.subscribe(&server_store, Self::handle_context_server_store_event),
         };
         for server in server_store.read(cx).running_servers() {
@@ -54,6 +59,14 @@ impl ContextServerRegistry {
             this.reload_prompts_for_server(server.id(), cx);
         }
         this
+    }
+
+    pub fn has_pending_tool_loads(&self) -> bool {
+        self.pending_tool_loads > 0
+    }
+
+    pub fn tools_ready_receiver(&self) -> watch::Receiver<usize> {
+        self.tools_ready_tx.receiver()
     }
 
     pub fn tools_for_server(
@@ -174,6 +187,9 @@ impl ContextServerRegistry {
             return;
         }
 
+        self.pending_tool_loads += 1;
+        let _ = self.tools_ready_tx.send(self.pending_tool_loads);
+
         let registered_server = self.get_or_register_server(&server_id, cx);
         registered_server.load_tools = cx.spawn(async move |this, cx| {
             let response = client
@@ -182,6 +198,8 @@ impl ContextServerRegistry {
 
             this.update(cx, |this, cx| {
                 let Some(registered_server) = this.registered_servers.get_mut(&server_id) else {
+                    this.pending_tool_loads = this.pending_tool_loads.saturating_sub(1);
+                    let _ = this.tools_ready_tx.send(this.pending_tool_loads);
                     return;
                 };
 
@@ -198,6 +216,9 @@ impl ContextServerRegistry {
                     cx.emit(ContextServerRegistryEvent::ToolsChanged);
                     cx.notify();
                 }
+
+                this.pending_tool_loads = this.pending_tool_loads.saturating_sub(1);
+                let _ = this.tools_ready_tx.send(this.pending_tool_loads);
             })
         });
     }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -889,27 +889,48 @@ impl AgentPanel {
                 while let Some(query) = query_rx.recv().await {
                     let query_id = query.query_id.clone();
                     this.update(cx, |this, cx| {
-                        let (active_view_str, thread_id, entry_count) = match &this.active_view {
+                        let (active_view_str, thread_id, entry_count, active_model) = match &this.active_view {
                             ActiveView::AgentThread { server_view } => {
                                 if let Some(acp_thread_view) = server_view.read(cx).active_thread() {
-                                    let thread_entity = &acp_thread_view.read(cx).thread;
+                                    let active_thread = acp_thread_view.read(cx);
+                                    let thread_entity = &active_thread.thread;
                                     let thread = thread_entity.read(cx);
+                                    let model_id = active_thread.current_model_id(cx);
                                     (
                                         "agent_thread".to_string(),
                                         Some(thread.session_id().to_string()),
                                         thread.entries().len(),
+                                        model_id,
                                     )
                                 } else {
-                                    ("agent_thread_loading".to_string(), None, 0)
+                                    ("agent_thread_loading".to_string(), None, 0, None)
                                 }
                             }
-                            ActiveView::History { .. } => ("history".to_string(), None, 0),
-                            ActiveView::Uninitialized => ("uninitialized".to_string(), None, 0),
-                            _ => ("other".to_string(), None, 0),
+                            ActiveView::History { .. } => ("history".to_string(), None, 0, None),
+                            ActiveView::Uninitialized => ("uninitialized".to_string(), None, 0, None),
+                            _ => ("other".to_string(), None, 0, None),
                         };
 
-                        eprintln!("🔍 [AGENT_PANEL] UI state query {}: active_view={}, thread_id={:?}, entry_count={}",
-                                  query_id, active_view_str, thread_id, entry_count);
+                        let mcp_servers = {
+                            let context_server_store = this.project.read(cx).context_server_store();
+                            let store = context_server_store.read(cx);
+                            let mut servers = std::collections::HashMap::new();
+                            for server_id in store.server_ids() {
+                                if let Some(status) = store.status_for_server(server_id) {
+                                    let status_str = match status {
+                                        project::context_server_store::ContextServerStatus::Running => "running",
+                                        project::context_server_store::ContextServerStatus::Starting => "starting",
+                                        project::context_server_store::ContextServerStatus::Stopped => "stopped",
+                                        project::context_server_store::ContextServerStatus::Error(_) => "error",
+                                    };
+                                    servers.insert(server_id.0.to_string(), status_str.to_string());
+                                }
+                            }
+                            servers
+                        };
+
+                        eprintln!("🔍 [AGENT_PANEL] UI state query {}: active_view={}, thread_id={:?}, entry_count={}, mcp_servers={:?}, active_model={:?}",
+                                  query_id, active_view_str, thread_id, entry_count, mcp_servers, active_model);
 
                         let _ = external_websocket_sync::send_websocket_event(
                             external_websocket_sync::SyncEvent::UiStateResponse {
@@ -917,6 +938,8 @@ impl AgentPanel {
                                 active_view: active_view_str,
                                 thread_id,
                                 entry_count,
+                                mcp_servers,
+                                active_model,
                             }
                         );
                     }).log_err();

--- a/crates/external_websocket_sync/e2e-test/.gitignore
+++ b/crates/external_websocket_sync/e2e-test/.gitignore
@@ -1,6 +1,7 @@
 # Pre-built binaries (copied from build output)
 zed-binary
 helix-ws-test-server/helix-ws-test-server
+slow-mcp-server/slow-mcp-server
 
 # Test artifacts
 screenshots/

--- a/crates/external_websocket_sync/e2e-test/Dockerfile
+++ b/crates/external_websocket_sync/e2e-test/Dockerfile
@@ -94,13 +94,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     mesa-vulkan-drivers \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy Zed binary from builder
-COPY --from=builder /zed-binary /usr/local/bin/zed
+# Copy pre-built Zed binary (built locally with `cargo build --features external_websocket_sync -p zed`)
+# Falls back to builder stage if zed-binary doesn't exist
+COPY crates/external_websocket_sync/e2e-test/zed-binary /usr/local/bin/zed
+RUN chmod +x /usr/local/bin/zed
 
 # Copy pre-built Go test server binary (statically linked, no runtime deps)
 # To rebuild: cd crates/external_websocket_sync/e2e-test/helix-ws-test-server && CGO_ENABLED=0 go build -o helix-ws-test-server .
 COPY crates/external_websocket_sync/e2e-test/helix-ws-test-server/helix-ws-test-server /usr/local/bin/helix-ws-test-server
 RUN chmod +x /usr/local/bin/helix-ws-test-server
+
+# Copy slow MCP server binary for MCP tools wait test
+COPY crates/external_websocket_sync/e2e-test/slow-mcp-server/slow-mcp-server /usr/local/bin/slow-mcp-server
+RUN chmod +x /usr/local/bin/slow-mcp-server
 
 # Copy test script
 COPY crates/external_websocket_sync/e2e-test/run_e2e.sh /test/run_e2e.sh

--- a/crates/external_websocket_sync/e2e-test/Dockerfile.runtime
+++ b/crates/external_websocket_sync/e2e-test/Dockerfile.runtime
@@ -37,7 +37,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copy pre-built binaries
 COPY zed-binary /usr/local/bin/zed
 COPY helix-ws-test-server/helix-ws-test-server /usr/local/bin/helix-ws-test-server
-RUN chmod +x /usr/local/bin/zed /usr/local/bin/helix-ws-test-server
+COPY slow-mcp-server/slow-mcp-server /usr/local/bin/slow-mcp-server
+RUN chmod +x /usr/local/bin/zed /usr/local/bin/helix-ws-test-server /usr/local/bin/slow-mcp-server
 
 # Copy test script
 COPY run_e2e.sh /test/run_e2e.sh

--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/go.mod
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/go.mod
@@ -138,7 +138,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-version v1.8.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
-	github.com/helixml/kodit v0.0.0-20260220184326-67ad35fe5b6b // indirect
+	github.com/helixml/kodit v1.1.2 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/infracloudio/msbotbuilder-go v0.2.5 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
@@ -213,7 +213,7 @@ require (
 	github.com/redis/go-redis/v9 v9.18.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/robfig/cron/v3 v3.0.2-0.20210106135023-bc59245fe10e // indirect
-	github.com/rs/zerolog v1.31.0 // indirect
+	github.com/rs/zerolog v1.34.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d // indirect
 	github.com/sashabaranov/go-openai v1.41.2 // indirect

--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/go.sum
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/go.sum
@@ -522,8 +522,8 @@ github.com/hashicorp/go-version v1.8.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/helixml/kodit v0.0.0-20260220184326-67ad35fe5b6b h1:JdokdOD748vpBXr7fB0gMWnqkVx1TMGtxvMvzXOKZh4=
-github.com/helixml/kodit v0.0.0-20260220184326-67ad35fe5b6b/go.mod h1:HafYCa7Tqgz3rJFnIgkNXJDjmgEvsvYVm9E041dVjqI=
+github.com/helixml/kodit v1.1.2 h1:CvweURZ9YrCXgpaY781BAbdbS65uoBHAIp64Q1qdLcg=
+github.com/helixml/kodit v1.1.2/go.mod h1:4HMeBt3mHHn6fdJoJtxExa9dn36xFd/vZRieM3DYwN8=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
@@ -782,9 +782,9 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rollbar/rollbar-go v1.0.2/go.mod h1:AcFs5f0I+c71bpHlXNNDbOWJiKwjFDtISeXco0L5PKQ=
-github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
-github.com/rs/zerolog v1.31.0 h1:FcTR3NnLWW+NnTwwhFWiJSZr4ECLpqCm6QsEnyvbV4A=
-github.com/rs/zerolog v1.31.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
+github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
+github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
+github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
@@ -54,6 +54,10 @@ type testDriver struct {
 
 	// Track UI state responses (from query_ui_state)
 	uiStateResponses []types.SyncMessage
+
+	// Track timing for MCP tools wait validation
+	phase1ChatSentAt    time.Time // when we sent the chat_message for phase 1
+	phase1ThreadCreated time.Time // when we received thread_created for phase 1
 }
 
 func newTestDriver(srv *server.HelixAPIServer, store *memorystore.MemoryStore) *testDriver {
@@ -85,6 +89,9 @@ func (d *testDriver) syncEventCallback(sessionID string, syncMsg *types.SyncMess
 			acpThreadID, _ = syncMsg.Data["context_id"].(string)
 		}
 		if acpThreadID != "" {
+			if len(d.threadIDs) == 0 {
+				d.phase1ThreadCreated = time.Now()
+			}
 			d.threadIDs = append(d.threadIDs, acpThreadID)
 			log.Printf("[test-server] Thread #%d: %s (event=%s)", len(d.threadIDs), truncate(acpThreadID, 16), syncMsg.EventType)
 		}
@@ -238,6 +245,9 @@ func (d *testDriver) runPhase1() {
 	log.Println("\n==================================================")
 	log.Println("  PHASE 1: Basic thread creation")
 	log.Println("==================================================")
+	d.mu.Lock()
+	d.phase1ChatSentAt = time.Now()
+	d.mu.Unlock()
 	d.sendChatMessage("What is 2 + 2? Reply with just the number.", "req-phase1", "zed-agent")
 }
 
@@ -491,6 +501,31 @@ func (d *testDriver) validate() bool {
 		}
 	}
 
+	// --- MCP TOOLS WAIT VALIDATION ---
+	log.Println("\n--------------------------------------------------")
+	log.Println("  MCP TOOLS WAIT VALIDATION")
+	log.Println("--------------------------------------------------")
+
+	if !d.phase1ChatSentAt.IsZero() && !d.phase1ThreadCreated.IsZero() {
+		mcpWaitDuration := d.phase1ThreadCreated.Sub(d.phase1ChatSentAt)
+		log.Printf("[test-server] MCP wait: chat_message sent -> thread_created = %s", mcpWaitDuration)
+
+		// The slow MCP server delays tools/list by 10 seconds.
+		// If wait_for_tools_ready() works, thread creation should be delayed
+		// by at least 8 seconds (allowing 2s buffer for server startup).
+		const minExpectedDelay = 8 * time.Second
+		if mcpWaitDuration < minExpectedDelay {
+			errors = append(errors, fmt.Sprintf(
+				"MCP tools wait: thread_created arrived %.1fs after chat_message (expected >= %.0fs). "+
+					"This means Zed did NOT wait for MCP tools to load before sending the first message.",
+				mcpWaitDuration.Seconds(), minExpectedDelay.Seconds()))
+		} else {
+			log.Printf("[test-server] MCP tools wait: Zed correctly waited %.1fs for tools to load", mcpWaitDuration.Seconds())
+		}
+	} else {
+		log.Println("[test-server] WARNING: Could not measure MCP tools wait (missing timestamps)")
+	}
+
 	// --- STREAMING VALIDATION ---
 	log.Println("\n--------------------------------------------------")
 	log.Println("  STREAMING VALIDATION")
@@ -608,6 +643,7 @@ func (d *testDriver) validate() bool {
 	log.Println("[test-server] Phase 5: Zed -> Helix user message sync - PASSED")
 	log.Println("[test-server] Phase 6: Query UI state - PASSED")
 	log.Println("[test-server] Phase 7: Open thread + follow-up - PASSED")
+	log.Println("[test-server] MCP tools wait: Zed waited for slow MCP server before first message - PASSED")
 	log.Println("[test-server] Store state: Sessions and interactions created correctly - PASSED")
 	log.Println("[test-server] Accumulation: ResponseMessage content preserved - PASSED")
 

--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
@@ -417,6 +417,46 @@ func (d *testDriver) validate() bool {
 			log.Printf("[test-server] Phase 6: UI state - active_view=%s, thread_id=%s, entry_count=%.0f",
 				activeView, truncate(threadID, 12), entryCount)
 		}
+
+		// Validate MCP server status
+		mcpServers, _ := resp.Data["mcp_servers"].(map[string]interface{})
+		if len(mcpServers) == 0 {
+			errors = append(errors, "Phase 6: ui_state_response mcp_servers is empty (expected at least slow-mcp-test)")
+		} else {
+			log.Printf("[test-server] Phase 6: MCP servers reported: %d", len(mcpServers))
+			slowMcpStatus, hasSlowMcp := mcpServers["slow-mcp-test"]
+			if !hasSlowMcp {
+				errors = append(errors, "Phase 6: mcp_servers missing 'slow-mcp-test' server")
+			} else if slowMcpStatus != "running" {
+				errors = append(errors, fmt.Sprintf(
+					"Phase 6: slow-mcp-test status=%q, expected 'running' (MCP server not connected)",
+					slowMcpStatus))
+			} else {
+				log.Printf("[test-server] Phase 6: slow-mcp-test MCP server is running (green/connected)")
+			}
+			for name, status := range mcpServers {
+				log.Printf("[test-server]   MCP server %q: %s", name, status)
+			}
+		}
+
+		// Validate active model matches settings.json configuration
+		activeModel, _ := resp.Data["active_model"].(string)
+		if activeModel == "" {
+			errors = append(errors, "Phase 6: ui_state_response active_model is empty (no model selected)")
+		} else {
+			log.Printf("[test-server] Phase 6: Active model: %s", activeModel)
+			// The settings.json configures "claude-sonnet-4-5-latest" as the default model.
+			// The model ID in Zed may include a provider prefix or resolve to a specific version,
+			// so we check that it contains "claude" as a sanity check that the Anthropic provider
+			// was selected (not zed.dev or some other default).
+			if !strings.Contains(strings.ToLower(activeModel), "claude") {
+				errors = append(errors, fmt.Sprintf(
+					"Phase 6: active_model=%q does not contain 'claude' — expected Anthropic model from settings.json",
+					activeModel))
+			} else {
+				log.Printf("[test-server] Phase 6: Model correctly set to Anthropic provider (contains 'claude')")
+			}
+		}
 	}
 
 	// Phase 7: open_thread + follow-up
@@ -642,6 +682,8 @@ func (d *testDriver) validate() bool {
 	log.Println("[test-server] Phase 4: Follow-up to non-visible thread - PASSED")
 	log.Println("[test-server] Phase 5: Zed -> Helix user message sync - PASSED")
 	log.Println("[test-server] Phase 6: Query UI state - PASSED")
+	log.Println("[test-server] Phase 6: MCP server connected (slow-mcp-test running) - PASSED")
+	log.Println("[test-server] Phase 6: Active model matches Anthropic provider config - PASSED")
 	log.Println("[test-server] Phase 7: Open thread + follow-up - PASSED")
 	log.Println("[test-server] MCP tools wait: Zed waited for slow MCP server before first message - PASSED")
 	log.Println("[test-server] Store state: Sessions and interactions created correctly - PASSED")

--- a/crates/external_websocket_sync/e2e-test/run_docker_e2e.sh
+++ b/crates/external_websocket_sync/e2e-test/run_docker_e2e.sh
@@ -43,12 +43,18 @@ if [ ! -f "$SCRIPT_DIR/zed-binary" ]; then
     exit 1
 fi
 
-# Build Go test server (unless --no-build)
+# Build Go binaries (unless --no-build)
 if [ "${1:-}" != "--no-build" ]; then
     echo "=== Building Go test server ==="
     cd "$SCRIPT_DIR/helix-ws-test-server"
     go build -o helix-ws-test-server .
     echo "Built: $SCRIPT_DIR/helix-ws-test-server/helix-ws-test-server"
+    echo ""
+
+    echo "=== Building slow MCP server ==="
+    cd "$SCRIPT_DIR/slow-mcp-server"
+    CGO_ENABLED=0 go build -o slow-mcp-server .
+    echo "Built: $SCRIPT_DIR/slow-mcp-server/slow-mcp-server"
     echo ""
 fi
 

--- a/crates/external_websocket_sync/e2e-test/run_e2e.sh
+++ b/crates/external_websocket_sync/e2e-test/run_e2e.sh
@@ -140,6 +140,12 @@ cat > "$ZED_CONFIG_DIR/settings.json" << JSONEOF
     "always_allow_tool_actions": true,
     "show_onboarding": false,
     "auto_open_panel": true
+  },
+  "context_servers": {
+    "slow-mcp-test": {
+      "enabled": true,
+      "command": "/usr/local/bin/slow-mcp-server"
+    }
   }
 }
 JSONEOF

--- a/crates/external_websocket_sync/e2e-test/run_e2e.sh
+++ b/crates/external_websocket_sync/e2e-test/run_e2e.sh
@@ -144,7 +144,8 @@ cat > "$ZED_CONFIG_DIR/settings.json" << JSONEOF
   "context_servers": {
     "slow-mcp-test": {
       "enabled": true,
-      "command": "/usr/local/bin/slow-mcp-server"
+      "command": "/usr/local/bin/slow-mcp-server",
+      "args": []
     }
   }
 }

--- a/crates/external_websocket_sync/e2e-test/slow-mcp-server/go.mod
+++ b/crates/external_websocket_sync/e2e-test/slow-mcp-server/go.mod
@@ -1,0 +1,3 @@
+module slow-mcp-server
+
+go 1.22

--- a/crates/external_websocket_sync/e2e-test/slow-mcp-server/main.go
+++ b/crates/external_websocket_sync/e2e-test/slow-mcp-server/main.go
@@ -1,0 +1,144 @@
+// slow-mcp-server is a minimal MCP (Model Context Protocol) stdio server that
+// deliberately delays its response to tools/list. It verifies that Zed's
+// wait_for_tools_ready() logic works — the first LLM request should not fire
+// until this server has finished loading its tools.
+//
+// Protocol: line-delimited JSON-RPC 2.0 over stdin/stdout.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+const toolsDelay = 10 * time.Second
+
+type jsonrpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type jsonrpcResponse struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   interface{} `json:"error,omitempty"`
+}
+
+func send(resp jsonrpcResponse) {
+	data, err := json.Marshal(resp)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[slow-mcp] Marshal error: %v\n", err)
+		return
+	}
+	fmt.Fprintf(os.Stdout, "%s\n", data)
+}
+
+func handleRequest(req jsonrpcRequest) {
+	switch req.Method {
+	case "initialize":
+		send(jsonrpcResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Result: map[string]interface{}{
+				"protocolVersion": "2024-11-05",
+				"capabilities": map[string]interface{}{
+					"tools": map[string]interface{}{
+						"listChanged": false,
+					},
+				},
+				"serverInfo": map[string]interface{}{
+					"name":    "slow-mcp-test-server",
+					"version": "1.0.0",
+				},
+			},
+		})
+
+	case "notifications/initialized":
+		// No response for notifications
+
+	case "tools/list":
+		fmt.Fprintf(os.Stderr, "[slow-mcp] Delaying tools/list response by %s...\n", toolsDelay)
+		time.Sleep(toolsDelay)
+		fmt.Fprintf(os.Stderr, "[slow-mcp] Sending tools/list response now.\n")
+		send(jsonrpcResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Result: map[string]interface{}{
+				"tools": []map[string]interface{}{
+					{
+						"name":        "slow_mcp_test_tool",
+						"description": "A dummy tool from the slow MCP test server. Its presence proves tools were loaded before the LLM request.",
+						"inputSchema": map[string]interface{}{
+							"type":       "object",
+							"properties": map[string]interface{}{},
+						},
+					},
+				},
+			},
+		})
+
+	case "tools/call":
+		send(jsonrpcResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Result: map[string]interface{}{
+				"content": []map[string]interface{}{
+					{"type": "text", "text": "slow_mcp_test_tool executed"},
+				},
+				"isError": false,
+			},
+		})
+
+	case "ping":
+		send(jsonrpcResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Result:  map[string]interface{}{},
+		})
+
+	default:
+		if req.ID != nil {
+			send(jsonrpcResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Error: map[string]interface{}{
+					"code":    -32601,
+					"message": fmt.Sprintf("Method not found: %s", req.Method),
+				},
+			})
+		}
+	}
+}
+
+func main() {
+	fmt.Fprintf(os.Stderr, "[slow-mcp] Server started, reading from stdin...\n")
+
+	scanner := bufio.NewScanner(os.Stdin)
+	// Increase buffer size for large messages
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		var req jsonrpcRequest
+		if err := json.Unmarshal([]byte(line), &req); err != nil {
+			fmt.Fprintf(os.Stderr, "[slow-mcp] Invalid JSON: %s\n", line)
+			continue
+		}
+
+		handleRequest(req)
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "[slow-mcp] Scanner error: %v\n", err)
+	}
+}

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -501,14 +501,17 @@ fn create_new_thread_sync(
     // NativeAgent::new() (called during connect) reads the model list via refresh_list().
     // If providers aren't authenticated yet, the model list is empty and new_thread()
     // creates threads with model=None, causing "No language model configured" errors.
-    {
+    let auth_tasks = {
         let registry = language_model::LanguageModelRegistry::global(cx);
         let providers = registry.read(cx).providers().clone();
         eprintln!("🔧 [THREAD_SERVICE] Pre-authenticating {} language model providers...", providers.len());
-        for provider in &providers {
-            eprintln!("🔧 [THREAD_SERVICE]   Authenticating provider: {}", provider.name().0);
-            provider.authenticate(cx);
-        }
+        let tasks: Vec<_> = providers
+            .iter()
+            .map(|provider| {
+                eprintln!("🔧 [THREAD_SERVICE]   Authenticating provider: {}", provider.name().0);
+                provider.authenticate(cx)
+            })
+            .collect();
 
         // Ensure the default model is selected in the registry
         let settings = agent_settings::AgentSettings::get_global(cx);
@@ -524,7 +527,8 @@ fn create_new_thread_sync(
                 eprintln!("🔧 [THREAD_SERVICE] Registry default_model set: {}", has);
             });
         }
-    }
+        tasks
+    };
 
     let agent = match request.agent_name.as_deref() {
         Some("zed-agent") | None => ExternalAgent::NativeAgent,
@@ -557,6 +561,13 @@ fn create_new_thread_sync(
     let request_clone = request.clone();
     let project_clone = project.clone();
     cx.spawn(async move |cx| {
+        // Await provider authentication so models are available when creating sessions
+        for task in auth_tasks {
+            if let Err(e) = task.await {
+                log::warn!("[THREAD_SERVICE] Provider authentication failed (continuing): {}", e);
+            }
+        }
+
         let (connection, _spawn_task): (std::rc::Rc<dyn acp_thread::AgentConnection>, _) = connection_task
             .await
             .log_err()

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -513,20 +513,6 @@ fn create_new_thread_sync(
             })
             .collect();
 
-        // Ensure the default model is selected in the registry
-        let settings = agent_settings::AgentSettings::get_global(cx);
-        if let Some(ref default_model) = settings.default_model {
-            eprintln!("🔧 [THREAD_SERVICE] Setting default model: {}/{}", default_model.provider.0, default_model.model);
-            let selected = language_model::SelectedModel {
-                provider: language_model::LanguageModelProviderId::from(default_model.provider.0.clone()),
-                model: language_model::LanguageModelId::from(default_model.model.clone()),
-            };
-            language_model::LanguageModelRegistry::global(cx).update(cx, |registry, cx| {
-                registry.select_default_model(Some(&selected), cx);
-                let has = registry.default_model().is_some();
-                eprintln!("🔧 [THREAD_SERVICE] Registry default_model set: {}", has);
-            });
-        }
         tasks
     };
 
@@ -541,32 +527,48 @@ fn create_new_thread_sync(
             },
         },
     };
-    let server = agent.server(fs, acp_history_store.clone());
-
-    // Get agent server store from project
-    let agent_server_store = project.read(cx).agent_server_store().clone();
-
-    // Create delegate for connection
-    let delegate = agent_servers::AgentServerDelegate::new(
-        agent_server_store,
-        project.clone(),
-        None, // status_tx
-        None, // new_version_tx
-    );
-
-    // Connect to get AgentConnection
-    let connection_task = server.connect(delegate, cx);
 
     // Spawn async task to complete the connection and create the thread
     let request_clone = request.clone();
     let project_clone = project.clone();
     cx.spawn(async move |cx| {
-        // Await provider authentication so models are available when creating sessions
+        // Await provider authentication so models are available when creating sessions.
+        // This MUST complete before server.connect(), because NativeAgent::new() reads
+        // the model list during construction. If auth hasn't populated the provider's
+        // model list yet, the agent gets no model and thread.send() fails.
         for task in auth_tasks {
             if let Err(e) = task.await {
                 log::warn!("[THREAD_SERVICE] Provider authentication failed (continuing): {}", e);
             }
         }
+        eprintln!("✅ [THREAD_SERVICE] Provider authentication complete, connecting agent...");
+
+        // Now that providers are authenticated, set the default model and connect
+        let connection_task = cx.update(|cx| {
+            // Re-select default model now that providers have their model lists
+            let settings = agent_settings::AgentSettings::get_global(cx);
+            if let Some(ref default_model) = settings.default_model {
+                let selected = language_model::SelectedModel {
+                    provider: language_model::LanguageModelProviderId::from(default_model.provider.0.clone()),
+                    model: language_model::LanguageModelId::from(default_model.model.clone()),
+                };
+                language_model::LanguageModelRegistry::global(cx).update(cx, |registry, cx| {
+                    registry.select_default_model(Some(&selected), cx);
+                    let has = registry.default_model().is_some();
+                    eprintln!("🔧 [THREAD_SERVICE] Registry default_model set: {}", has);
+                });
+            }
+
+            let server = agent.server(fs, acp_history_store.clone());
+            let agent_server_store = project.read(cx).agent_server_store().clone();
+            let delegate = agent_servers::AgentServerDelegate::new(
+                agent_server_store,
+                project.clone(),
+                None,
+                None,
+            );
+            server.connect(delegate, cx)
+        });
 
         let (connection, _spawn_task): (std::rc::Rc<dyn acp_thread::AgentConnection>, _) = connection_task
             .await

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -588,9 +588,15 @@ fn create_new_thread_sync(
                         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default())
                 })
             });
+        let connection_for_tools = connection.clone();
         let thread_entity: Entity<AcpThread> = cx.update(|cx| {
             connection.new_session(project_clone.clone(), &cwd, cx)
         }).await?;
+
+        // Wait for MCP context server tools to finish loading before sending
+        // the first message, so the LLM request includes all available tools.
+        let tools_ready_task = cx.update(|cx| connection_for_tools.wait_for_tools_ready(cx));
+        tools_ready_task.await;
 
         let acp_thread_id = cx.update(|cx| {
             let thread_id = thread_entity.read(cx).session_id().to_string();

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -17,7 +17,6 @@ use fs::Fs;
 use project::Project;
 use tokio::sync::mpsc;
 use util::ResultExt;
-use settings::Settings as _;
 use crate::{ExternalAgent, ThreadCreationRequest, ThreadOpenRequest, SyncEvent};
 
 /// Global registry of active ACP threads (service layer)
@@ -497,25 +496,6 @@ fn create_new_thread_sync(
 ) -> Result<()> {
     log::info!("[THREAD_SERVICE] Creating ACP thread with agent: {:?}", request.agent_name);
 
-    // Ensure language model providers are authenticated before connecting.
-    // NativeAgent::new() (called during connect) reads the model list via refresh_list().
-    // If providers aren't authenticated yet, the model list is empty and new_thread()
-    // creates threads with model=None, causing "No language model configured" errors.
-    let auth_tasks = {
-        let registry = language_model::LanguageModelRegistry::global(cx);
-        let providers = registry.read(cx).providers().clone();
-        eprintln!("🔧 [THREAD_SERVICE] Pre-authenticating {} language model providers...", providers.len());
-        let tasks: Vec<_> = providers
-            .iter()
-            .map(|provider| {
-                eprintln!("🔧 [THREAD_SERVICE]   Authenticating provider: {}", provider.name().0);
-                provider.authenticate(cx)
-            })
-            .collect();
-
-        tasks
-    };
-
     let agent = match request.agent_name.as_deref() {
         Some("zed-agent") | None => ExternalAgent::NativeAgent,
         Some(name) => ExternalAgent::Custom {
@@ -532,33 +512,7 @@ fn create_new_thread_sync(
     let request_clone = request.clone();
     let project_clone = project.clone();
     cx.spawn(async move |cx| {
-        // Await provider authentication so models are available when creating sessions.
-        // This MUST complete before server.connect(), because NativeAgent::new() reads
-        // the model list during construction. If auth hasn't populated the provider's
-        // model list yet, the agent gets no model and thread.send() fails.
-        for task in auth_tasks {
-            if let Err(e) = task.await {
-                log::warn!("[THREAD_SERVICE] Provider authentication failed (continuing): {}", e);
-            }
-        }
-        eprintln!("✅ [THREAD_SERVICE] Provider authentication complete, connecting agent...");
-
-        // Now that providers are authenticated, set the default model and connect
         let connection_task = cx.update(|cx| {
-            // Re-select default model now that providers have their model lists
-            let settings = agent_settings::AgentSettings::get_global(cx);
-            if let Some(ref default_model) = settings.default_model {
-                let selected = language_model::SelectedModel {
-                    provider: language_model::LanguageModelProviderId::from(default_model.provider.0.clone()),
-                    model: language_model::LanguageModelId::from(default_model.model.clone()),
-                };
-                language_model::LanguageModelRegistry::global(cx).update(cx, |registry, cx| {
-                    registry.select_default_model(Some(&selected), cx);
-                    let has = registry.default_model().is_some();
-                    eprintln!("🔧 [THREAD_SERVICE] Registry default_model set: {}", has);
-                });
-            }
-
             let server = agent.server(fs, acp_history_store.clone());
             let agent_server_store = project.read(cx).agent_server_store().clone();
             let delegate = agent_servers::AgentServerDelegate::new(
@@ -602,9 +556,61 @@ fn create_new_thread_sync(
                 })
             });
         let connection_for_tools = connection.clone();
+        let connection_for_model = connection.clone();
         let thread_entity: Entity<AcpThread> = cx.update(|cx| {
             connection.new_session(project_clone.clone(), &cwd, cx)
         }).await?;
+
+        // Wait for the NativeAgent's model list to be populated.
+        // NativeAgent::new() spawns authenticate_all_language_model_providers()
+        // which runs asynchronously. When it completes, ProviderStateChanged
+        // fires, NativeAgent refreshes its model list. We wait for that refresh.
+        let session_id = cx.update(|cx| thread_entity.read(cx).session_id().clone());
+        {
+            let mut model_watch = cx.update(|cx| {
+                connection_for_model.model_selector(&session_id)
+                    .and_then(|selector| selector.watch(cx))
+            });
+            if let Some(ref mut watch_rx) = model_watch {
+                let wait_for_models = async {
+                    let _ = watch_rx.changed().await;
+                };
+                let timeout = async {
+                    smol::Timer::after(std::time::Duration::from_secs(15)).await;
+                    log::warn!("[THREAD_SERVICE] Timed out waiting for models (15s), proceeding");
+                };
+                futures::future::select(Box::pin(wait_for_models), Box::pin(timeout)).await;
+            }
+        }
+
+        // The settings system may set the default model to zed.dev (from default.json),
+        // which can't be resolved without a Zed account. The NativeAgent's auto-model
+        // logic uses registry.default_model() which may return None in this case.
+        // If the thread still has no model after the watch fired, explicitly select
+        // the first available model from the authenticated providers.
+        if let Some(selector) = cx.update(|_cx| connection_for_model.model_selector(&session_id)) {
+            let has_model = cx.update(|cx| selector.selected_model(cx)).await;
+            let needs_model = match has_model {
+                Ok(_) => false,
+                Err(_) => true,
+            };
+            if needs_model {
+                let model_list_result = cx.update(|cx| selector.list_models(cx)).await;
+                if let Ok(model_list) = model_list_result {
+                    let first_model_id = match &model_list {
+                        acp_thread::AgentModelList::Flat(models) => models.first().map(|m| m.id.clone()),
+                        acp_thread::AgentModelList::Grouped(groups) => {
+                            groups.values().flat_map(|v| v.iter()).next().map(|m| m.id.clone())
+                        }
+                    };
+                    if let Some(model_id) = first_model_id {
+                        if let Err(e) = cx.update(|cx| selector.select_model(model_id.clone(), cx)).await {
+                            log::warn!("[THREAD_SERVICE] Failed to select model: {}", e);
+                        }
+                    }
+                }
+            }
+        }
 
         // Wait for MCP context server tools to finish loading before sending
         // the first message, so the LLM request includes all available tools.

--- a/crates/external_websocket_sync/src/types.rs
+++ b/crates/external_websocket_sync/src/types.rs
@@ -229,6 +229,10 @@ pub enum SyncEvent {
         thread_id: Option<String>,
         /// Number of entries in the displayed thread
         entry_count: usize,
+        /// MCP context server statuses: server name -> status string ("running", "starting", "stopped", "error")
+        mcp_servers: HashMap<String, String>,
+        /// Currently selected model ID for the active thread (if available)
+        active_model: Option<String>,
     },
 }
 
@@ -290,13 +294,15 @@ impl SyncEvent {
                     "thread_id": thread_id,
                 })
             ),
-            SyncEvent::UiStateResponse { query_id, active_view, thread_id, entry_count } => (
+            SyncEvent::UiStateResponse { query_id, active_view, thread_id, entry_count, mcp_servers, active_model } => (
                 "ui_state_response".to_string(),
                 serde_json::json!({
                     "query_id": query_id,
                     "active_view": active_view,
                     "thread_id": thread_id,
                     "entry_count": entry_count,
+                    "mcp_servers": mcp_servers,
+                    "active_model": active_model,
                 })
             ),
         };


### PR DESCRIPTION
## Summary

- Fix race condition where the first LLM request via WebSocket fires with zero MCP tools because `ContextServerRegistry` loads tools asynchronously via `ListTools` RPC, but `Thread::run_turn()` reads them synchronously
- Fix "No language model configured" error by using `AgentModelSelector` to wait for provider auth and explicitly select the first available model (the default `zed.dev` model can't resolve without a Zed account)
- Add pending-load tracking with a `watch` channel to `ContextServerRegistry`, expose `wait_for_tools_ready()` on the `AgentConnection` trait, and await it in `thread_service.rs` before sending the first message
- Enhanced `wait_for_tools_ready` to also wait for configured-but-unregistered context servers (handles async server startup)
- Default trait implementation returns immediately, so existing agents (HeadlessConnection, AcpConnection, test stubs) are unaffected

## Changes

### Model selection (`thread_service.rs`)
- Replaced pre-auth + settings-based model selection with `AgentModelSelector` approach
- Wait for model list watch to fire (15s timeout) after `new_session()` creates the thread
- If thread still has no model, query `list_models()` and `select_model()` with first available

### MCP tools wait (`agent.rs`, `context_server_registry.rs`)
- Added `registered_server_count()` to `ContextServerRegistry`
- `wait_for_tools_ready()` now also checks for configured-but-unregistered servers
- Wait loop checks both `has_pending_tool_loads()` and `registered_server_count() >= expected`

### E2E test infrastructure (`Dockerfile`, `run_e2e.sh`)
- Added slow-mcp-server binary to Docker image
- Added `context_servers` settings with `"args": []` (required for deserialization)

## Test plan

- [x] `cargo build --features external_websocket_sync -p zed` compiles
- [x] `cargo test -p external_websocket_sync` — 37 tests pass
- [x] `cargo test -p acp_thread` — 39 tests pass
- [x] E2E: All 7 phases pass, MCP tools wait validation passes (Zed waits for slow MCP server before first message)

Release Notes:

- N/A