### PR TITLE
Fix auto-follow mode and split-brain for external WebSocket sessions

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -579,6 +579,14 @@ impl AcpServerView {
         ];
 
         cx.on_release(|this, cx| {
+            // Unregister thread from THREAD_REGISTRY so stale entries don't
+            // cause split-brain when the same session is loaded via the UI path.
+            if let ServerState::Connected(connected) = &this.server_state {
+                if let Some(id) = &connected.active_id {
+                    let session_id_str = id.to_string();
+                    external_websocket_sync::unregister_thread(&session_id_str);
+                }
+            }
             for window in this.notifications.drain(..) {
                 window
                     .update(cx, |_, window, _| {

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1831,7 +1831,7 @@ impl AgentPanel {
             // running in the background.
             #[cfg(feature = "external_websocket_sync")]
             if let Some(ActiveView::AgentThread { server_view }) = &self.previous_view {
-                if let Some(active_thread) = server_view.read(cx).active_thread() {
+                if let Some(active_thread) = server_view.read(cx).active_thread().cloned() {
                     active_thread.update(cx, |thread_view, cx| {
                         thread_view.cancel_generation(cx);
                     });
@@ -1848,7 +1848,7 @@ impl AgentPanel {
                 // previous_view before dropping it.
                 #[cfg(feature = "external_websocket_sync")]
                 if let Some(ActiveView::AgentThread { server_view }) = &self.previous_view {
-                    if let Some(active_thread) = server_view.read(cx).active_thread() {
+                    if let Some(active_thread) = server_view.read(cx).active_thread().cloned() {
                         active_thread.update(cx, |thread_view, cx| {
                             thread_view.cancel_generation(cx);
                         });

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -816,6 +816,19 @@ impl AgentPanel {
                             if let Some(active_thread) = server_view.read(cx).active_thread() {
                                 if active_thread.read(cx).thread == notification.thread_entity {
                                     eprintln!("🔄 [AGENT_PANEL] Already showing thread {} with same entity, skipping", incoming_session_id);
+
+                                    // Activate following for follow-up messages from Helix.
+                                    // The view already exists but follow may have lapsed after
+                                    // the previous generation completed.
+                                    let should_follow = active_thread.read(cx).should_be_following;
+                                    if should_follow {
+                                        if let Some(workspace) = this.workspace.upgrade() {
+                                            workspace.update(cx, |workspace, cx| {
+                                                workspace.follow(CollaboratorId::Agent, window, cx);
+                                            });
+                                        }
+                                    }
+
                                     return;
                                 }
                                 eprintln!("🔄 [AGENT_PANEL] Thread {} entity changed (container restart?), rebinding to new entity", incoming_session_id);
@@ -864,6 +877,22 @@ impl AgentPanel {
                                 Rc::new(NativeAgentSessionList::new(thread_store, cx));
                             history.set_session_list(Some(session_list), cx);
                         });
+
+                        // Activate following for externally-initiated threads.
+                        // AcpThreadView defaults should_be_following to true, so new
+                        // threads from Helix will auto-follow the agent's location.
+                        if let ActiveView::AgentThread { server_view } = &this.active_view {
+                            if let Some(active_thread) = server_view.read(cx).active_thread() {
+                                let should_follow = active_thread.read(cx).should_be_following;
+                                if should_follow {
+                                    if let Some(workspace) = this.workspace.upgrade() {
+                                        workspace.update(cx, |workspace, cx| {
+                                            workspace.follow(CollaboratorId::Agent, window, cx);
+                                        });
+                                    }
+                                }
+                            }
+                        }
 
                         eprintln!("✅ [AGENT_PANEL] Auto-opened existing headless thread {} in UI", incoming_session_id);
                     }).log_err();
@@ -1795,11 +1824,36 @@ impl AgentPanel {
         let new_is_special = new_is_history || new_is_config;
 
         if current_is_uninitialized || (current_is_special && !new_is_special) {
+            // Transitioning from History/Config to a new AgentThread (e.g., user
+            // clicked a thread from the history list). If previous_view holds a
+            // stale AgentThread with a running generation, cancel it now — the
+            // user has chosen a different thread, so the old one should not keep
+            // running in the background.
+            #[cfg(feature = "external_websocket_sync")]
+            if let Some(ActiveView::AgentThread { server_view }) = &self.previous_view {
+                if let Some(active_thread) = server_view.read(cx).active_thread() {
+                    active_thread.update(cx, |thread_view, cx| {
+                        thread_view.cancel_generation(cx);
+                    });
+                }
+            }
+            self.previous_view = None;
             self.active_view = new_view;
         } else if !current_is_special && new_is_special {
             self.previous_view = Some(std::mem::replace(&mut self.active_view, new_view));
         } else {
             if !new_is_special {
+                // Replacing one AgentThread with another directly (not via
+                // History). Cancel any running generation in the stale
+                // previous_view before dropping it.
+                #[cfg(feature = "external_websocket_sync")]
+                if let Some(ActiveView::AgentThread { server_view }) = &self.previous_view {
+                    if let Some(active_thread) = server_view.read(cx).active_thread() {
+                        active_thread.update(cx, |thread_view, cx| {
+                            thread_view.cancel_generation(cx);
+                        });
+                    }
+                }
                 self.previous_view = None;
             }
             self.active_view = new_view;

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -822,11 +822,15 @@ impl AgentPanel {
                                     // the previous generation completed.
                                     let should_follow = active_thread.read(cx).should_be_following;
                                     if should_follow {
+                                        eprintln!("🔄 [AGENT_PANEL] Activating auto-follow for follow-up message (same entity path)");
                                         if let Some(workspace) = this.workspace.upgrade() {
                                             workspace.update(cx, |workspace, cx| {
                                                 workspace.follow(CollaboratorId::Agent, window, cx);
                                             });
+                                            eprintln!("✅ [AGENT_PANEL] workspace.follow(Agent) called successfully (follow-up)");
                                         }
+                                    } else {
+                                        eprintln!("⏸️ [AGENT_PANEL] Auto-follow disabled by user, skipping follow (follow-up)");
                                     }
 
                                     return;
@@ -885,12 +889,18 @@ impl AgentPanel {
                             if let Some(active_thread) = server_view.read(cx).active_thread() {
                                 let should_follow = active_thread.read(cx).should_be_following;
                                 if should_follow {
+                                    eprintln!("🔄 [AGENT_PANEL] Activating auto-follow for new external thread");
                                     if let Some(workspace) = this.workspace.upgrade() {
                                         workspace.update(cx, |workspace, cx| {
                                             workspace.follow(CollaboratorId::Agent, window, cx);
                                         });
+                                        eprintln!("✅ [AGENT_PANEL] workspace.follow(Agent) called successfully (new thread)");
                                     }
+                                } else {
+                                    eprintln!("⏸️ [AGENT_PANEL] Auto-follow disabled by user, skipping follow (new thread)");
                                 }
+                            } else {
+                                eprintln!("⚠️ [AGENT_PANEL] No active_thread found after set_active_view, cannot activate follow");
                             }
                         }
 

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -234,7 +234,35 @@ pub fn register_thread(acp_thread_id: String, thread: Entity<AcpThread>) {
     init_thread_registry();
     let registry = THREAD_REGISTRY.lock();
     if let Some(reg) = registry.as_ref() {
-        reg.write().insert(acp_thread_id, thread);
+        let mut map = reg.write();
+        if let Some(existing) = map.get(&acp_thread_id) {
+            if existing.entity_id() != thread.entity_id() {
+                log::warn!(
+                    "⚠️ [THREAD_SERVICE] register_thread: overwriting thread '{}' with different entity (old={:?}, new={:?})",
+                    acp_thread_id,
+                    existing.entity_id(),
+                    thread.entity_id(),
+                );
+                eprintln!(
+                    "⚠️ [THREAD_SERVICE] register_thread: overwriting thread '{}' with different entity (old={:?}, new={:?})",
+                    acp_thread_id,
+                    existing.entity_id(),
+                    thread.entity_id(),
+                );
+            }
+        }
+        map.insert(acp_thread_id, thread);
+    }
+}
+
+/// Remove a thread from the registry (e.g., when a headless view is dropped).
+pub fn unregister_thread(acp_thread_id: &str) {
+    let registry = THREAD_REGISTRY.lock();
+    if let Some(reg) = registry.as_ref() {
+        if reg.write().remove(acp_thread_id).is_some() {
+            eprintln!("🗑️ [THREAD_SERVICE] unregister_thread: removed '{}'", acp_thread_id);
+            log::info!("🗑️ [THREAD_SERVICE] unregister_thread: removed '{}'", acp_thread_id);
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

Two related bugs when Helix sends messages to Zed via the external WebSocket sync layer:

### Bug 1: Auto-follow mode not activating for external messages

When messages arrive from Helix, the code path in `thread_service.rs` injects messages via `AcpThread::send()` and never calls `workspace.follow(CollaboratorId::Agent)`. This means the editor doesn't scroll to follow the agent's file edits — the user has to manually navigate to see what the agent is doing.

**Root cause**: The `ThreadDisplayNotification` handler in `AgentPanel::new` creates the UI view and focuses the panel but never activates following. Compare with the user-initiated path in `AcpThreadView::send_impl()` which explicitly calls `workspace.follow()`.

### Bug 2: Split-brain — duplicate agent instances after view switching

A specific navigation sequence (AgentThread → History → select thread from list) causes two `NativeAgent` instances to run in parallel on the same worktree:

1. Helix sends message → `thread_service` creates Thread-A with NativeAgent-A, wraps in View-A via `from_existing_thread` (uses `HeadlessConnection`)
2. User clicks "View All" → `set_active_view(History)` stashes View-A in `previous_view`
3. User clicks a thread from history → creates new View-B with NativeAgent-B
4. `set_active_view(AgentThread { View-B })` sets active view but `previous_view` is never cleared in the `special → non-special` branch
5. Thread-A's `NativeAgent` continues executing tool calls on the same worktree

## Solution

### Bug 1 fix (`agent_panel.rs`)

Add `workspace.follow(CollaboratorId::Agent)` in the `ThreadDisplayNotification` handler, in both the new-view creation path and the early-return same-entity path. The follow is conditional on `should_be_following` (which defaults to `true` for new threads), so the user's toggle is respected.

### Bug 2 fix (`agent_panel.rs`, `thread_service.rs`, `thread_view.rs`)

- In `set_active_view`: When transitioning from History/Config to a new AgentThread (`special → non-special` branch), cancel any running generation in `previous_view` before dropping it. Same for the `else` branch (direct thread-to-thread replacement). Gated behind `#[cfg(feature = "external_websocket_sync")]`.
- Add `unregister_thread()` to clean up the thread registry when a headless view is dropped (in `from_existing_thread`'s `on_release` callback).
- Add diagnostic logging in `register_thread()` when overwriting an existing entry with a different entity.

## Testing

- `./stack build-zed release` passes
- `./stack build-ubuntu` passes
- Manual testing of the follow-up and navigation flows needed (see checklist below)

### Manual test checklist

- [ ] Send message from Helix web UI → verify Zed editor follows agent edits
- [ ] Toggle follow off → verify it stays off for subsequent messages
- [ ] Send follow-up message → verify follow re-activates
- [ ] Start long-running task → navigate to thread list → click different thread → verify only one agent running
- [ ] Test "back" button from History still works

Release Notes:

- N/A
