### PR TITLE
We recently significantly changed how the chat session in...

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -4658,6 +4658,94 @@ mod tests {
         );
     }
 
+    // Test that Stopped is emitted for every completed turn, even when a second send()
+    // displaces an active turn. This is the invariant Helix depends on: every
+    // AcpThread::send() call must eventually produce AcpThreadEvent::Stopped so that
+    // Helix can pop the FIFO queue (message_completed) and route the next response correctly.
+    #[gpui::test]
+    async fn test_second_send_during_active_turn_emits_stopped_for_both_turns(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+
+        // Block the first handler until explicitly signalled.
+        let (first_unblock_tx, first_unblock_rx) = futures::channel::oneshot::channel::<()>();
+        let first_unblock_rx = RefCell::new(Some(first_unblock_rx));
+
+        let connection = Rc::new(FakeAgentConnection::new().on_user_message({
+            move |params, _thread, _cx| {
+                let first_unblock_rx = first_unblock_rx.borrow_mut().take();
+                let is_first = params
+                    .prompt
+                    .iter()
+                    .any(|c| matches!(c, acp::ContentBlock::Text(t) if t.text.contains("first")));
+                async move {
+                    if is_first {
+                        if let Some(rx) = first_unblock_rx {
+                            rx.await.ok();
+                        }
+                    }
+                    Ok(acp::PromptResponse::new(acp::StopReason::EndTurn))
+                }
+                .boxed_local()
+            }
+        }));
+
+        let thread = cx
+            .update(|cx| connection.new_session(project, Path::new(path!("/test")), cx))
+            .await
+            .unwrap();
+
+        // Count Stopped events. Helix pops the FIFO queue on each Stopped, so every
+        // turn must emit exactly one — whether it completed normally or was displaced.
+        // Rc<RefCell> is sufficient because GPUI runs everything on a single foreground thread.
+        let stopped_count = Rc::new(RefCell::new(0usize));
+        thread.update(cx, |_, cx| {
+            cx.subscribe(
+                &thread,
+                {
+                    let stopped_count = stopped_count.clone();
+                    move |_, _, event: &AcpThreadEvent, _| {
+                        if matches!(event, AcpThreadEvent::Stopped) {
+                            *stopped_count.borrow_mut() += 1;
+                        }
+                    }
+                },
+            )
+            .detach();
+        });
+
+        // Turn 1 starts and blocks inside the fake connection handler.
+        let first_turn = thread.update(cx, |thread, cx| thread.send_raw("first", cx));
+
+        // Turn 2 is sent while turn 1 is still blocked. run_turn() calls cancel() which
+        // takes ownership of turn 1's running_turn and returns a Task that resolves when
+        // turn 1 finishes. Turn 2's spawned task awaits that Task before starting, so
+        // the two turns are strictly serialised: turn 1 completes, then turn 2 begins.
+        let second_turn = thread.update(cx, |thread, cx| thread.send_raw("second", cx));
+
+        assert_eq!(
+            thread.read_with(cx, |t, _| t.turn_id),
+            2,
+            "turn_id should advance to 2 after second send"
+        );
+
+        // Unblock turn 1. Turn 2 will start only after turn 1's send_task finishes.
+        first_unblock_tx.send(()).ok();
+
+        first_turn.await.unwrap();
+        second_turn.await.unwrap();
+
+        assert_eq!(
+            *stopped_count.borrow(),
+            2,
+            "Stopped must be emitted once per turn: once for the displaced turn 1 and once for turn 2"
+        );
+    }
+
     #[gpui::test]
     async fn test_send_returns_cancelled_response_and_marks_tools_as_cancelled(
         cx: &mut TestAppContext,

--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
@@ -3,7 +3,7 @@
 // with an in-memory store, so the same message processing code runs in both
 // tests and production.
 //
-// The server implements 7 phases:
+// The server implements 8 phases:
 //
 //	Phase 1: Basic thread creation (new chat_message, no thread ID)
 //	Phase 2: Follow-up on existing thread (same thread ID)
@@ -12,6 +12,7 @@
 //	Phase 5: Simulate user input (Zed -> Helix sync direction)
 //	Phase 6: Query UI state (verify Zed reports active thread)
 //	Phase 7: Open thread + follow-up (open_thread command then chat_message)
+//	Phase 8: Mid-stream interrupt (send follow-up while previous response is streaming)
 //
 // Exit codes: 0 = all tests passed, 1 = test failure
 package main
@@ -59,6 +60,11 @@ type testDriver struct {
 	// Track timing for MCP tools wait validation
 	phase1ChatSentAt    time.Time // when we sent the chat_message for phase 1
 	phase1ThreadCreated time.Time // when we received thread_created for phase 1
+
+	// Phase 8: mid-stream interrupt state
+	phase8ThreadID      string // thread ID created in phase 8
+	phase8InterruptSent bool   // whether we have already sent the interrupt
+	phase8Completions   int    // number of message_completed events received for phase 8 thread
 }
 
 func newTestDriver(srv *server.HelixAPIServer, store *memorystore.MemoryStore) *testDriver {
@@ -95,6 +101,27 @@ func (d *testDriver) syncEventCallback(sessionID string, syncMsg *types.SyncMess
 			}
 			d.threadIDs = append(d.threadIDs, acpThreadID)
 			log.Printf("[test-server] Thread #%d: %s (event=%s)", len(d.threadIDs), truncate(acpThreadID, 16), syncMsg.EventType)
+			// Capture the thread created for phase 8 so we can send the interrupt to it.
+			if d.phase == 8 && d.phase8ThreadID == "" {
+				d.phase8ThreadID = acpThreadID
+				log.Printf("[test-server] Phase 8: Captured thread ID: %s", truncate(acpThreadID, 16))
+			}
+		}
+
+	case "message_added":
+		// Phase 8: send an interrupt as soon as the first assistant token arrives for
+		// the phase 8 thread. This guarantees ACP has started generating (running_turn
+		// is set), so the interrupt will properly cancel the active turn via run_turn().
+		if d.phase == 8 && !d.phase8InterruptSent {
+			role, _ := syncMsg.Data["role"].(string)
+			threadID, _ := syncMsg.Data["acp_thread_id"].(string)
+			if role == "assistant" && threadID == d.phase8ThreadID {
+				d.phase8InterruptSent = true
+				d.mu.Unlock()
+				log.Printf("[test-server] Phase 8: First assistant token arrived, sending interrupt to %s", truncate(threadID, 16))
+				d.sendChatMessage("Actually just say 'hello'.", "req-phase8-interrupt", "zed-agent", threadID)
+				return
+			}
 		}
 
 	case "message_completed":
@@ -102,6 +129,23 @@ func (d *testDriver) syncEventCallback(sessionID string, syncMsg *types.SyncMess
 		requestID, _ := syncMsg.Data["request_id"].(string)
 		d.completions[acpThreadID] = append(d.completions[acpThreadID], requestID)
 		currentPhase := d.phase
+
+		// Phase 8 needs two completions before the test can end: one for the cancelled
+		// initial turn and one for the interrupt response.
+		if currentPhase == 8 && acpThreadID == d.phase8ThreadID {
+			d.phase8Completions++
+			completions := d.phase8Completions
+			d.mu.Unlock()
+			log.Printf("[test-server] Phase 8: Completion %d/2 for thread=%s req=%s",
+				completions, truncate(acpThreadID, 12), requestID)
+			if completions >= 2 {
+				log.Println("[test-server] Phase 8: Both turns completed (cancelled + interrupt)")
+				time.Sleep(500 * time.Millisecond)
+				close(d.done)
+			}
+			return
+		}
+
 		d.mu.Unlock()
 
 		log.Printf("[test-server] Completed: thread=%s req=%s (phase %d)",
@@ -229,8 +273,7 @@ func (d *testDriver) advanceAfterCompletion(completedPhase int) {
 		d.mu.Lock()
 		d.phase = 8
 		d.mu.Unlock()
-		time.Sleep(500 * time.Millisecond)
-		close(d.done)
+		d.runPhase8()
 	}
 }
 
@@ -335,6 +378,20 @@ func (d *testDriver) runPhase7() {
 
 	log.Printf("[test-server] Sending follow-up to Thread B after open_thread")
 	d.sendChatMessage("What is 8 + 8? Reply with just the number.", "req-phase7", "zed-agent", tid)
+}
+
+func (d *testDriver) runPhase8() {
+	log.Println("\n==================================================")
+	log.Println("  PHASE 8: Mid-stream interrupt")
+	log.Println("==================================================")
+	// Send a question that will generate a streaming response long enough for us
+	// to send an interrupt before it completes. The syncEventCallback will fire the
+	// interrupt the moment the first assistant token arrives.
+	d.sendChatMessage(
+		"Write me a detailed explanation of recursion with three worked examples.",
+		"req-phase8-initial",
+		"zed-agent",
+	)
 }
 
 // --- Validation ---
@@ -461,11 +518,60 @@ func (d *testDriver) validate() bool {
 		errors = append(errors, "Phase 7: No message_completed for req-phase7")
 	}
 
+	// Phase 8: mid-stream interrupt
+	// We expect two message_completed events for the phase 8 thread:
+	//   1. The cancelled initial turn (ACP cancel -> Stopped -> message_completed)
+	//   2. The interrupt response (normal completion)
+	if d.phase8ThreadID == "" {
+		errors = append(errors, "Phase 8: No thread ID captured (phase 8 may not have run)")
+	} else {
+		completionsForPhase8 := len(d.completions[d.phase8ThreadID])
+		if completionsForPhase8 < 2 {
+			errors = append(errors, fmt.Sprintf(
+				"Phase 8: Expected 2 message_completed events (cancelled turn + interrupt), got %d",
+				completionsForPhase8))
+		} else {
+			log.Printf("[test-server] Phase 8: Received %d completions for phase 8 thread (correct)", completionsForPhase8)
+		}
+	}
+	if !d.hasCompletion("req-phase8-interrupt") {
+		errors = append(errors, "Phase 8: No message_completed for req-phase8-interrupt")
+	}
+
+	// Verify ordering: no assistant tokens for the interrupt arrived before the first
+	// message_completed for the phase 8 thread. This is the core invariant: the FIFO
+	// queue on the Helix side requires message_completed(I_A) before any I_B tokens.
+	if d.phase8ThreadID != "" && d.hasCompletion("req-phase8-interrupt") {
+		seenFirstCompletion := false
+		orderingViolation := false
+		for _, e := range d.events {
+			threadID, _ := e.Data["acp_thread_id"].(string)
+			if threadID != d.phase8ThreadID {
+				continue
+			}
+			if e.EventType == "message_completed" && !seenFirstCompletion {
+				seenFirstCompletion = true
+			}
+			if e.EventType == "message_added" && !seenFirstCompletion {
+				role, _ := e.Data["role"].(string)
+				reqID, _ := e.Data["request_id"].(string)
+				if role == "assistant" && reqID == "req-phase8-interrupt" {
+					orderingViolation = true
+				}
+			}
+		}
+		if orderingViolation {
+			errors = append(errors, "Phase 8: Interrupt assistant tokens arrived before the first message_completed (FIFO ordering violated)")
+		} else {
+			log.Println("[test-server] Phase 8: Ordering correct — interrupt tokens arrived after first message_completed")
+		}
+	}
+
 	// Too many threads (follow-ups should not create new threads)
-	// Phases 1, 3 each create one thread = 2 threads total.
-	// Phases 2, 4, 5, 7 use existing threads.
-	if len(threadCreatedEvents) > 2 {
-		errors = append(errors, fmt.Sprintf("Too many thread_created events (%d, expected 2)", len(threadCreatedEvents)))
+	// Phases 1, 3, 8 each create one thread = 3 threads total.
+	// Phases 2, 4, 5, 7 use existing threads. Phase 8 interrupt uses the phase 8 thread.
+	if len(threadCreatedEvents) > 3 {
+		errors = append(errors, fmt.Sprintf("Too many thread_created events (%d, expected 3)", len(threadCreatedEvents)))
 	}
 
 	// --- STORE STATE VALIDATION (production handlers actually worked) ---
@@ -479,8 +585,8 @@ func (d *testDriver) validate() bool {
 	log.Printf("[test-server] Sessions in store: %d", len(sessions))
 	log.Printf("[test-server] Interactions in store: %d", len(interactions))
 
-	if len(sessions) < 2 {
-		errors = append(errors, fmt.Sprintf("Expected at least 2 sessions (Thread A + Thread B), got %d", len(sessions)))
+	if len(sessions) < 3 {
+		errors = append(errors, fmt.Sprintf("Expected at least 3 sessions (Thread A + Thread B + Phase 8), got %d", len(sessions)))
 	}
 
 	// Check that sessions have ZedThreadID metadata
@@ -492,8 +598,8 @@ func (d *testDriver) validate() bool {
 				truncate(s.ID, 12), truncate(s.Metadata.ZedThreadID, 12), s.Owner, s.Name)
 		}
 	}
-	if sessionsWithThread < 2 {
-		errors = append(errors, fmt.Sprintf("Expected at least 2 sessions with ZedThreadID, got %d", sessionsWithThread))
+	if sessionsWithThread < 3 {
+		errors = append(errors, fmt.Sprintf("Expected at least 3 sessions with ZedThreadID, got %d", sessionsWithThread))
 	}
 
 	// Check completed interactions have non-empty ResponseMessage


### PR DESCRIPTION
> **Helix**: We recently significantly changed how the chat session in the spec task detail page works, and we now have a couple of fresh issues to solve.
1. I just recently clicked approve SPEC, and it sent a message to the agent saying "Your implementation has been approved", but the response to that message got added to a previous interaction in the front end, even though it should have been associated with the new interaction that corresponds with the "Your implementation has been approved" message.
2. I think we probably already had this bug. When you send a message in queue mode (which is the default), it gets added to the Helix chat interface straight away but doesn't actually get sent to the agent until the agent has finished. It would be better if it waited in the queue until the agent was finished, which is the queue in the front end.

---
[Created by Helix](https://helix.ml)
