### PR TITLE
agent_ui: Suppress Zed Pro upsell in Helix builds

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -3049,6 +3049,11 @@ impl AgentPanel {
     }
 
     fn should_render_onboarding(&self, cx: &mut Context<Self>) -> bool {
+        // In Helix builds, AI is configured centrally; don't show Zed Pro ads.
+        if cfg!(feature = "external_websocket_sync") {
+            return false;
+        }
+
         if self.on_boarding_upsell_dismissed.load(Ordering::Acquire) {
             return false;
         }


### PR DESCRIPTION
## Summary

On a fresh Helix install the `dismissed-trial-upsell` KVP key is absent, so `should_render_onboarding()` returns `true` and the "Welcome to Zed AI" / Zed Pro advertisement renders in the agent panel sidebar. In Helix builds, AI is configured centrally via the settings-sync-daemon, so this advertisement is irrelevant and confusing.

## Changes

- Added a `cfg!(feature = "external_websocket_sync")` early-return guard at the top of `AgentPanel::should_render_onboarding()` in `crates/agent_ui/src/agent_panel.rs`, matching the pattern used for the migration banner suppression (`commit 2f74e89657`)

Release Notes:

- Fixed Zed Pro advertisement appearing in the agent panel on first startup in Helix builds

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01km6qrvfme7qxx8hwnahfgx0p) | 📋 [Requirements](https://github.com/helixml/zed/blob/helix-specs/design/tasks/001608_when-zed-first-starts-up/requirements.md) | [Design](https://github.com/helixml/zed/blob/helix-specs/design/tasks/001608_when-zed-first-starts-up/design.md) | [Tasks](https://github.com/helixml/zed/blob/helix-specs/design/tasks/001608_when-zed-first-starts-up/tasks.md) | 🚀 Built with [Helix](https://helix.ml)