### PR TITLE
title_bar: Restore WebSocket sync status icon lost in rebase

### DIFF
--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -14,6 +14,7 @@ doctest = false
 
 [features]
 default = []
+external_websocket_sync = ["dep:external_websocket_sync"]
 stories = ["dep:story"]
 test-support = [
     "call/test-support",
@@ -38,7 +39,7 @@ chrono.workspace = true
 client.workspace = true
 cloud_api_types.workspace = true
 db.workspace = true
-external_websocket_sync.workspace = true
+external_websocket_sync = { workspace = true, optional = true }
 feature_flags.workspace = true
 git_ui.workspace = true
 gpui = { workspace = true, features = ["screen-capture"] }

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [features]
 tracy = ["ztracing/tracy"]
-external_websocket_sync = ["agent_ui/external_websocket_sync", "dep:external_websocket_sync"]
+external_websocket_sync = ["agent_ui/external_websocket_sync", "dep:external_websocket_sync", "title_bar/external_websocket_sync"]
 test-support = [
     "gpui/test-support",
     "gpui_platform/screen-capture",

--- a/portingguide.md
+++ b/portingguide.md
@@ -168,7 +168,8 @@ These files contain Helix-specific changes that must be preserved during rebases
 
 ### `crates/title_bar/`
 - **Helix connection status indicator**: Shows WebSocket connection status in the title bar
-- Depends on `external_websocket_sync` crate
+- **`external_websocket_sync` must be optional**: In `title_bar/Cargo.toml`, the dep must be `external_websocket_sync = { workspace = true, optional = true }` and the `[features]` section must include `external_websocket_sync = ["dep:external_websocket_sync"]`. Without this, `#[cfg(feature = "external_websocket_sync")]` always evaluates to false and the icon never renders.
+- **Feature propagation**: `crates/zed/Cargo.toml`'s `external_websocket_sync` feature must include `"title_bar/external_websocket_sync"` to enable the feature when building with Helix support.
 
 ### `crates/http_client_tls/src/http_client_tls.rs`
 - **`NoCertVerifier`**: Skips TLS certificate verification when `ZED_HTTP_INSECURE_TLS=1`


### PR DESCRIPTION
## Summary

The Helix WebSocket connection status icon disappeared from the Zed title bar after the 2026-03-22 upstream rebase.

During the rebase, `#[cfg(feature = "external_websocket_sync")]` gates were added around the import and `render_helix_connection_status()` in `title_bar.rs`. However, `title_bar/Cargo.toml` never defined an `external_websocket_sync` feature (or made the dep optional), so the cfg gate always evaluated to `false`. Only the stub function (returning `None`) compiled — the icon never rendered.

## Changes

- `crates/title_bar/Cargo.toml`: make `external_websocket_sync` dep optional; add `external_websocket_sync = ["dep:external_websocket_sync"]` to `[features]`
- `crates/zed/Cargo.toml`: add `"title_bar/external_websocket_sync"` to the existing `external_websocket_sync` feature list so the feature activates when building with Helix support
- `portingguide.md`: document this requirement so it isn't lost in future rebases

## Release Notes

- N/A

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kmfngg2vdvvgrybj1ebynrz6)

📋 Spec:
- [Requirements](https://github.com/helixml/zed/blob/helix-specs/design/tasks/001631_we-seem-to-have-lost-the/requirements.md)
- [Design](https://github.com/helixml/zed/blob/helix-specs/design/tasks/001631_we-seem-to-have-lost-the/design.md)
- [Tasks](https://github.com/helixml/zed/blob/helix-specs/design/tasks/001631_we-seem-to-have-lost-the/tasks.md)

🚀 Built with [Helix](https://helix.ml)