### PR TITLE
During streaming, I still see truncated sentences. The se...

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1064,8 +1064,6 @@ pub struct AcpThread {
 struct StreamingTextBuffer {
     /// Text received from the model but not yet appended to the Markdown source.
     pending: String,
-    /// The number of bytes to reveal per timer turn.
-    bytes_to_reveal_per_tick: usize,
     /// The Markdown entity being streamed into.
     target: Entity<Markdown>,
     /// Timer task that periodically moves text from `pending` into `source`.
@@ -1073,11 +1071,10 @@ struct StreamingTextBuffer {
 }
 
 impl StreamingTextBuffer {
-    /// The number of milliseconds between each timer tick, controlling how quickly
-    /// text is revealed.
+    /// The number of milliseconds between each timer tick. The timer batches
+    /// incoming tokens so we don't call `markdown.append` per-character, but
+    /// each tick drains the entire pending buffer.
     const TASK_UPDATE_MS: u64 = 16;
-    /// The time in milliseconds to reveal the entire pending text.
-    const REVEAL_TARGET: f32 = 200.0;
 }
 
 impl From<&AcpThread> for ActionLogTelemetry {
@@ -1603,11 +1600,6 @@ impl AcpThread {
         if let Some(buffer) = &mut self.streaming_text_buffer {
             if buffer.target.entity_id() == markdown.entity_id() {
                 buffer.pending.push_str(&text);
-
-                buffer.bytes_to_reveal_per_tick = (buffer.pending.len() as f32
-                    / StreamingTextBuffer::REVEAL_TARGET
-                    * StreamingTextBuffer::TASK_UPDATE_MS as f32)
-                    .ceil() as usize;
                 return;
             }
             Self::flush_streaming_text(&mut self.streaming_text_buffer, cx);
@@ -1615,13 +1607,8 @@ impl AcpThread {
 
         let target = markdown.clone();
         let _reveal_task = self.start_streaming_reveal(cx);
-        let pending_len = text.len();
-        let bytes_to_reveal = (pending_len as f32 / StreamingTextBuffer::REVEAL_TARGET
-            * StreamingTextBuffer::TASK_UPDATE_MS as f32)
-            .ceil() as usize;
         self.streaming_text_buffer = Some(StreamingTextBuffer {
             pending: text,
-            bytes_to_reveal_per_tick: bytes_to_reveal,
             target,
             _reveal_task,
         });
@@ -1661,16 +1648,13 @@ impl AcpThread {
                             return true;
                         }
 
-                        let pending_len = buffer.pending.len();
-
-                        let byte_boundary = buffer
-                            .pending
-                            .ceil_char_boundary(buffer.bytes_to_reveal_per_tick)
-                            .min(pending_len);
-
+                        // Drain the entire pending buffer each tick. The 16ms timer
+                        // still batches (avoids per-character appends), but we never
+                        // withhold bytes — content_only(cx) reads markdown.source()
+                        // so any unrevealed bytes would be invisible to WebSocket sync.
+                        let full = std::mem::take(&mut buffer.pending);
                         buffer.target.update(cx, |markdown: &mut Markdown, cx| {
-                            markdown.append(&buffer.pending[..byte_boundary], cx);
-                            buffer.pending.drain(..byte_boundary);
+                            markdown.append(&full, cx);
                         });
 
                         true

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -165,6 +165,46 @@ fn init_streaming_throttle() {
     }
 }
 
+/// Flush pending throttled content for all entries in a thread OTHER than the
+/// specified entry index. Called from the NewEntry handler to ensure the
+/// preceding text entry's content is sent before a new entry (e.g. tool_call).
+fn flush_stale_pending_for_thread(acp_thread_id: &str, exclude_entry_idx: usize) {
+    init_streaming_throttle();
+    let thread_prefix = format!("{}:", acp_thread_id);
+    let exclude_key = format!("{}:{}", acp_thread_id, exclude_entry_idx);
+    let now = Instant::now();
+
+    let mut stale_pending: Vec<PendingMessage> = Vec::new();
+    {
+        let throttle_map = STREAMING_THROTTLE.lock();
+        let Some(map) = throttle_map.as_ref() else { return };
+        let mut map = map.write();
+
+        for (k, state) in map.iter_mut() {
+            if k.starts_with(&thread_prefix) && *k != exclude_key {
+                if let Some(pending) = state.pending_content.take() {
+                    state.last_sent = now;
+                    stale_pending.push(pending);
+                }
+            }
+        }
+    }
+
+    for pending in stale_pending {
+        let _ = crate::send_websocket_event(SyncEvent::MessageAdded {
+            acp_thread_id: pending.acp_thread_id,
+            message_id: pending.message_id,
+            role: pending.role,
+            content: pending.content,
+            request_id: pending.request_id,
+            entry_type: pending.entry_type,
+            tool_name: pending.tool_name,
+            tool_status: pending.tool_status,
+            timestamp: chrono::Utc::now().timestamp(),
+        });
+    }
+}
+
 /// Throttled send of message_added events. Only sends if enough time has passed
 /// since the last send for this entry. Otherwise, stores the content as pending.
 /// Returns true if the event was sent, false if throttled.
@@ -211,7 +251,12 @@ fn throttled_send_message_added(
             pending_content: None,
         });
 
-        if now.duration_since(state.last_sent) >= STREAMING_THROTTLE_INTERVAL {
+        // Tool call entries bypass the throttle — they're infrequent and must
+        // arrive promptly so the preceding text entry's stale-pending flush
+        // reaches the API before the tool call does.
+        if now.duration_since(state.last_sent) >= STREAMING_THROTTLE_INTERVAL
+            || entry_type == "tool_call"
+        {
             state.last_sent = now;
             state.pending_content = None;
             current_to_send = Some(PendingMessage {
@@ -479,6 +524,12 @@ fn ensure_thread_subscription(
                     if role == "assistant" {
                         *turn_request_id.borrow_mut() = rid.clone();
                     }
+                    // Flush pending throttled content for other entries before
+                    // sending this new entry. Without this, a tool_call entry
+                    // arrives at the API before the preceding text entry's final
+                    // content, causing truncated text in the frontend.
+                    flush_stale_pending_for_thread(&thread_id_for_sub, latest_idx);
+
                     let _ = crate::send_websocket_event(SyncEvent::MessageAdded {
                         acp_thread_id: thread_id_for_sub.clone(),
                         message_id: latest_idx.to_string(),

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -524,13 +524,16 @@ fn ensure_thread_subscription(
                     if role == "assistant" {
                         *turn_request_id.borrow_mut() = rid.clone();
                     }
-                    // Before sending the new entry, re-send ALL preceding entries
-                    // with their current content. flush_streaming_text() was called
-                    // right before push_entry(), so all Markdown entities have their
-                    // complete text. The old approach (flush_stale_pending_for_thread)
-                    // only sent the *throttled snapshot* which may be missing final
-                    // tokens that arrived between the last EntryUpdated and now.
-                    for prev_idx in 0..latest_idx {
+                    // Re-send preceding entries FROM THE CURRENT TURN with their
+                    // current content. flush_streaming_text() was called right before
+                    // push_entry(), so all Markdown entities have their complete text.
+                    // Only send entries after the last UserMessage to avoid leaking
+                    // old turn entries into the current interaction on the Go side.
+                    let entries = thread.entries();
+                    let turn_start = entries.iter().enumerate().rev()
+                        .find_map(|(i, e)| matches!(e, acp_thread::AgentThreadEntry::UserMessage(_)).then_some(i + 1))
+                        .unwrap_or(0);
+                    for prev_idx in turn_start..latest_idx {
                         if let Some(prev_entry) = thread.entries().get(prev_idx) {
                             let (prev_role, prev_content, prev_entry_type) = match prev_entry {
                                 acp_thread::AgentThreadEntry::UserMessage(msg) => {

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -524,11 +524,45 @@ fn ensure_thread_subscription(
                     if role == "assistant" {
                         *turn_request_id.borrow_mut() = rid.clone();
                     }
-                    // Flush pending throttled content for other entries before
-                    // sending this new entry. Without this, a tool_call entry
-                    // arrives at the API before the preceding text entry's final
-                    // content, causing truncated text in the frontend.
-                    flush_stale_pending_for_thread(&thread_id_for_sub, latest_idx);
+                    // Before sending the new entry, re-send ALL preceding entries
+                    // with their current content. flush_streaming_text() was called
+                    // right before push_entry(), so all Markdown entities have their
+                    // complete text. The old approach (flush_stale_pending_for_thread)
+                    // only sent the *throttled snapshot* which may be missing final
+                    // tokens that arrived between the last EntryUpdated and now.
+                    for prev_idx in 0..latest_idx {
+                        if let Some(prev_entry) = thread.entries().get(prev_idx) {
+                            let (prev_role, prev_content, prev_entry_type) = match prev_entry {
+                                acp_thread::AgentThreadEntry::UserMessage(msg) => {
+                                    ("user", msg.content.to_markdown(cx).to_string(), "text")
+                                }
+                                acp_thread::AgentThreadEntry::AssistantMessage(msg) => {
+                                    ("assistant", msg.content_only(cx), "text")
+                                }
+                                acp_thread::AgentThreadEntry::ToolCall(tool_call) => {
+                                    ("assistant", tool_call.to_markdown(cx), "tool_call")
+                                }
+                                _ => continue,
+                            };
+                            let (prev_tool_name, prev_tool_status) = match prev_entry {
+                                acp_thread::AgentThreadEntry::ToolCall(tool_call) => {
+                                    (tool_call.label.read(cx).source().to_string(), tool_call.status.to_string())
+                                }
+                                _ => (String::new(), String::new()),
+                            };
+                            let _ = crate::send_websocket_event(SyncEvent::MessageAdded {
+                                acp_thread_id: thread_id_for_sub.clone(),
+                                message_id: prev_idx.to_string(),
+                                role: prev_role.to_string(),
+                                content: prev_content,
+                                request_id: rid.clone(),
+                                entry_type: prev_entry_type.to_string(),
+                                tool_name: prev_tool_name,
+                                tool_status: prev_tool_status,
+                                timestamp: chrono::Utc::now().timestamp(),
+                            });
+                        }
+                    }
 
                     let _ = crate::send_websocket_event(SyncEvent::MessageAdded {
                         acp_thread_id: thread_id_for_sub.clone(),


### PR DESCRIPTION
During streaming, I still see truncated sentences. The sentences are almost always truncated prior to a tool call, I think. It's like there's a 100 ms poll or whatever it is inside Zed that somehow doesn't update some sentences some of the time, although when the interaction completes, we do correctly get them all updated. Can you investigate this? I think there's multiple levels here:
1. Zed sends updates to the API.
2. The API also sends updates to the front end with patches on the response entries.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kn9w07a9kw9bdv1av7ajnv1c)

📋 Spec:
- [Requirements](https://github.com/helixml/zed/blob/helix-specs/design/tasks/001694_during-streaming-i-still/requirements.md)
- [Design](https://github.com/helixml/zed/blob/helix-specs/design/tasks/001694_during-streaming-i-still/design.md)
- [Tasks](https://github.com/helixml/zed/blob/helix-specs/design/tasks/001694_during-streaming-i-still/tasks.md)

🚀 Built with [Helix](https://helix.ml)