### PR TITLE
fix: session resume sync - serialize startup, fix agent_type, send agent_ready

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1107,6 +1107,12 @@ impl AgentPanel {
                             _ => crate::Agent::NativeAgent,
                         };
 
+                        // Update selected_agent_type so serialization saves the correct type.
+                        // Without this, the panel serializes as NativeAgent, and on next
+                        // startup the restoration check goes through the sqlite path (which
+                        // fails for ACP agents), preventing thread restoration.
+                        this.selected_agent_type = connection_agent.clone().into();
+
                         let server = connection_agent.server(this.fs.clone(), this.thread_store.clone());
 
                         let history = this

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -946,6 +946,19 @@ impl AgentPanel {
                             );
                         }
                     });
+                    // agent_ready is sent by initial_state's completion handler
+                    // when the thread load finishes (see conversation_view.rs)
+                } else {
+                    // No thread to restore — send agent_ready immediately so
+                    // the server knows Zed is ready and can flush its queue.
+                    // Without this, the server waits 60s for agent_ready.
+                    #[cfg(feature = "external_websocket_sync")]
+                    {
+                        external_websocket_sync::send_agent_ready(
+                            "zed-agent".to_string(),
+                            None,
+                        );
+                    }
                 }
                 panel
             })?;

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -851,6 +851,21 @@ impl AgentPanel {
                 })?
                 .await?;
 
+            // Wait for WebSocket to connect before restoring threads.
+            // This ensures the agent_ready → open_thread handshake can complete:
+            // 1. WebSocket connects
+            // 2. Panel restoration loads thread from ACP storage (with shared lock)
+            // 3. Zed sends agent_ready
+            // 4. Server sends open_thread (which is a no-op if same thread, or loads
+            //    a different thread if the server wants to switch)
+            // The connection is local or DC-to-DC so this is fast (~100ms).
+            #[cfg(feature = "external_websocket_sync")]
+            {
+                external_websocket_sync::wait_for_websocket_connected(
+                    std::time::Duration::from_secs(10),
+                ).await;
+            }
+
             let last_active_thread = if let Some(thread_info) = serialized_panel
                 .as_ref()
                 .and_then(|p| p.last_active_thread.as_ref())

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -758,6 +758,10 @@ impl ConversationView {
         // Register thread in THREAD_REGISTRY
         {
             let session_id_str = id.to_string();
+            eprintln!(
+                "📋 [CONV_VIEW] from_existing_thread: registering entity {:?} for session {}",
+                thread.entity_id(), session_id_str
+            );
             external_websocket_sync::register_thread(session_id_str, thread);
         }
 
@@ -991,7 +995,12 @@ impl ConversationView {
                         #[cfg(feature = "external_websocket_sync")]
                         {
                             let session_id = current.read(cx).thread.read(cx).session_id().to_string();
-                            external_websocket_sync::register_thread(session_id, current.read(cx).thread.clone());
+                            let entity = current.read(cx).thread.clone();
+                            eprintln!(
+                                "📋 [CONV_VIEW] initial_state: registering entity {:?} for session {} (is_resume={})",
+                                entity.entity_id(), session_id, is_resume
+                            );
+                            external_websocket_sync::register_thread(session_id, entity);
                         }
 
                         let id = current.read(cx).thread.read(cx).session_id().clone();

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -899,6 +899,28 @@ impl ConversationView {
 
             telemetry::event!("Agent Thread Started", agent = connection.telemetry_id());
 
+            // Acquire the shared thread load lock to prevent racing with
+            // open_existing_thread_sync in thread_service. Only one thread load
+            // can be in progress at a time. Use a drop guard so the lock is
+            // released on all exit paths (success, error, early return).
+            #[cfg(feature = "external_websocket_sync")]
+            struct LoadLockGuard(bool);
+            #[cfg(feature = "external_websocket_sync")]
+            impl Drop for LoadLockGuard {
+                fn drop(&mut self) {
+                    if self.0 {
+                        external_websocket_sync::release_thread_load_lock();
+                    }
+                }
+            }
+            #[cfg(feature = "external_websocket_sync")]
+            let _load_lock_guard = if load_session_id.is_some() {
+                let sid = load_session_id.as_ref().unwrap().0.to_string();
+                LoadLockGuard(external_websocket_sync::try_acquire_thread_load_lock(&sid))
+            } else {
+                LoadLockGuard(false)
+            };
+
             let mut resumed_without_history = false;
             let result = if let Some(session_id) = load_session_id.clone() {
                 cx.update(|_, cx| {
@@ -1011,12 +1033,8 @@ impl ConversationView {
                                 external_websocket_sync::ensure_thread_subscription(
                                     &entity, &session_id, cx,
                                 );
-                                let agent_name = match &this.agent {
-                                    agent if agent.agent_id().0.contains("claude") => "claude",
-                                    _ => "zed-agent",
-                                };
                                 external_websocket_sync::send_agent_ready(
-                                    agent_name.to_string(),
+                                    this.agent.agent_id().0.to_string(),
                                     Some(session_id),
                                 );
                             }

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -1000,7 +1000,26 @@ impl ConversationView {
                                 "📋 [CONV_VIEW] initial_state: registering entity {:?} for session {} (is_resume={})",
                                 entity.entity_id(), session_id, is_resume
                             );
-                            external_websocket_sync::register_thread(session_id, entity);
+                            external_websocket_sync::register_thread(session_id.clone(), entity.clone());
+
+                            // When panel restoration resumes a thread, set up the WebSocket
+                            // sync subscription and send agent_ready. Panel restoration
+                            // bypasses the thread_service path (which normally does both),
+                            // so we must do it here. Without agent_ready, the server waits
+                            // 60s before flushing the open_thread/chat_message queue.
+                            if is_resume {
+                                external_websocket_sync::ensure_thread_subscription(
+                                    &entity, &session_id, cx,
+                                );
+                                let agent_name = match &this.agent {
+                                    agent if agent.agent_id().0.contains("claude") => "claude",
+                                    _ => "zed-agent",
+                                };
+                                external_websocket_sync::send_agent_ready(
+                                    agent_name.to_string(),
+                                    Some(session_id),
+                                );
+                            }
                         }
 
                         let id = current.read(cx).thread.read(cx).session_id().clone();

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -478,6 +478,16 @@ fn ensure_thread_subscription(
         return;
     }
 
+    let entity_id = thread_entity.entity_id();
+    eprintln!(
+        "🔔 [THREAD_SERVICE] Creating NEW subscription for thread {} on entity {:?}",
+        thread_id, entity_id
+    );
+    log::info!(
+        "🔔 [THREAD_SERVICE] Creating NEW subscription for thread {} on entity {:?}",
+        thread_id, entity_id
+    );
+
     let thread_id_for_sub = thread_id.to_string();
     mark_persistent_subscription(thread_id.to_string());
 
@@ -489,7 +499,13 @@ fn ensure_thread_subscription(
         crate::get_thread_request_id(thread_id).unwrap_or_default()
     );
 
+    let sub_entity_id = entity_id;
     cx.subscribe(thread_entity, move |thread_entity, event, cx| {
+        let current_entity_id = thread_entity.entity_id();
+        eprintln!(
+            "🔔 [THREAD_SERVICE] Subscription FIRED for thread {} on entity {:?} (subscribed to {:?}), event: {:?}",
+            thread_id_for_sub, current_entity_id, sub_entity_id, std::mem::discriminant(event)
+        );
         match event {
             AcpThreadEvent::NewEntry => {
                 let thread = thread_entity.read(cx);

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -468,7 +468,7 @@ pub fn get_thread(acp_thread_id: &str) -> Option<WeakEntity<AcpThread>> {
 /// - `NewEntry`: new user/assistant message → send `message_added`
 /// - `EntryUpdated`: streaming tokens / tool call updates → throttled `message_added`
 /// - `Stopped`: turn completed → flush throttle + send `message_completed`
-fn ensure_thread_subscription(
+pub fn ensure_thread_subscription(
     thread_entity: &Entity<AcpThread>,
     thread_id: &str,
     cx: &mut App,

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -61,6 +61,31 @@ static PERSISTENT_SUBSCRIPTIONS: parking_lot::Mutex<Option<Arc<RwLock<HashSet<St
 static THREAD_LOAD_IN_PROGRESS: parking_lot::Mutex<Option<String>> =
     parking_lot::Mutex::new(None);
 
+/// Try to acquire the thread load lock. Returns true if acquired (no other
+/// load in progress), false if another thread is currently loading.
+/// Must be paired with `release_thread_load_lock` when the load completes.
+pub fn try_acquire_thread_load_lock(thread_id: &str) -> bool {
+    let mut loading = THREAD_LOAD_IN_PROGRESS.lock();
+    if loading.is_some() {
+        eprintln!(
+            "⏳ [THREAD_SERVICE] Thread load lock busy (current={:?}), skipping load of {}",
+            loading, thread_id
+        );
+        false
+    } else {
+        eprintln!("🔒 [THREAD_SERVICE] Acquired thread load lock for {} (from panel restoration)", thread_id);
+        *loading = Some(thread_id.to_string());
+        true
+    }
+}
+
+/// Release the thread load lock after a load completes or fails.
+pub fn release_thread_load_lock() {
+    let mut loading = THREAD_LOAD_IN_PROGRESS.lock();
+    eprintln!("🔓 [THREAD_SERVICE] Released thread load lock (was {:?}, from panel restoration)", loading);
+    *loading = None;
+}
+
 /// Streaming throttle state per message entry.
 /// Keyed by "{thread_id}:{entry_idx}" to support multi-entry streaming.
 static STREAMING_THROTTLE: parking_lot::Mutex<Option<Arc<RwLock<HashMap<String, StreamingThrottleState>>>>> =

--- a/crates/external_websocket_sync/src/websocket_sync.rs
+++ b/crates/external_websocket_sync/src/websocket_sync.rs
@@ -690,3 +690,4 @@ pub fn get_websocket_connection_status() -> WebSocketConnectionStatus {
         None => WebSocketConnectionStatus::NotInitialized,
     }
 }
+

--- a/crates/external_websocket_sync/src/websocket_sync.rs
+++ b/crates/external_websocket_sync/src/websocket_sync.rs
@@ -691,3 +691,29 @@ pub fn get_websocket_connection_status() -> WebSocketConnectionStatus {
     }
 }
 
+/// Wait for the WebSocket to connect, with a timeout.
+/// Returns true if connected, false if timed out.
+/// Called during panel deserialization to ensure the WebSocket is ready
+/// before the panel tries to restore threads. This guarantees the
+/// agent_ready → open_thread handshake can complete.
+pub async fn wait_for_websocket_connected(timeout: std::time::Duration) -> bool {
+    let start = std::time::Instant::now();
+    let poll_interval = std::time::Duration::from_millis(50);
+
+    loop {
+        match get_websocket_connection_status() {
+            WebSocketConnectionStatus::Connected => {
+                log::info!("✅ [WEBSOCKET] wait_for_websocket_connected: connected after {:?}", start.elapsed());
+                return true;
+            }
+            _ => {
+                if start.elapsed() >= timeout {
+                    log::warn!("⚠️ [WEBSOCKET] wait_for_websocket_connected: timed out after {:?}", timeout);
+                    return false;
+                }
+                smol::Timer::after(poll_interval).await;
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary

Fixes the race condition on container restart where Zed's panel restoration and the server's `open_thread` command race, creating duplicate entities with broken WebSocket sync subscriptions.

- Fix `selected_agent_type` not updated when `notify_thread_display` creates `from_existing_thread`
- Wait for WebSocket connection before panel restoration
- Call `ensure_thread_subscription` + `send_agent_ready` from panel restoration path
- Send `agent_ready` even when no thread to restore
- Share `THREAD_LOAD_IN_PROGRESS` lock between panel restoration and thread_service

Companion Helix PR: helixml/helix#2153

🤖 Generated with [Claude Code](https://claude.com/claude-code)