### PR TITLE
fix: call ensure_thread_subscription in open_existing_thread_sync

### DIFF
--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -1619,6 +1619,15 @@ fn open_existing_thread_sync(
             log::info!("📋 [THREAD_SERVICE] Registered thread: {} (strong reference)", acp_thread_id);
         }
 
+        // CRITICAL: Subscribe to thread events so streaming responses sync to Helix.
+        // This mirrors create_new_thread_sync (line ~1218). Without this call,
+        // after a Zed restart the thread loads successfully but its NewEntry /
+        // EntryUpdated / Stopped events have no listener, so message_added is
+        // never emitted and the interaction stays stuck in "waiting" forever.
+        cx.update(|cx| {
+            ensure_thread_subscription(&thread_entity, &acp_thread_id, cx);
+        });
+
         // Send agent_ready event to Helix (signals that agent is ready to receive prompts)
         // (THREAD_LOAD_IN_PROGRESS is cleared by the ClearLoadingGuard drop guard)
         let agent_name_for_ready = request_clone.agent_name.clone().unwrap_or_else(|| "zed-agent".to_string());


### PR DESCRIPTION
## Problem

After a Zed restart, when Helix sends `open_thread` for an existing thread followed by `chat_message`, the interaction stays stuck in `waiting` state forever. Zed makes LLM calls and does work but never emits `message_added` events back to Helix.

## Root Cause

`open_existing_thread_sync` loaded the thread and sent `agent_ready` but never called `ensure_thread_subscription`. Without that call the thread's `NewEntry` / `EntryUpdated` / `Stopped` events have no listener, so no `message_added` events are ever emitted back to Helix.

`create_new_thread_sync` always called `ensure_thread_subscription` (correctly). The slow path in `open_existing_thread_sync` — used when the thread is not in the in-memory registry after a restart — was missing it.

## Why Phase 12 E2E Test Didn't Catch This

Phase 12 tests the restart-reconnect flow but was passing via a different code path: after `f3a2622736` (2026-04-06), Zed's panel restoration reruns on restart and restores spec task threads, calling `ensure_thread_subscription` via that path. The `open_thread` command then hits the fast path (`get_thread()` returns Some, already subscribed). Production spec-task sessions don't go through panel restoration, so they always hit the slow path.

## Fix

Add the missing `ensure_thread_subscription` call in `open_existing_thread_sync` before `send_agent_ready`, mirroring `create_new_thread_sync`.

## Test plan

- [ ] Run E2E test: `E2E_AGENTS="zed-agent,claude" ./run_docker_e2e.sh`
- [ ] Phase 12 should continue to pass
- [ ] Manual: restart agent mid-session, send a message, verify response appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)