### PR TITLE
fix: thread subscription stability + phase 8 FIFO ordering for interrupts

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1027,6 +1027,10 @@ pub struct RetryStatus {
 struct RunningTurn {
     id: u32,
     send_task: Task<()>,
+    /// Set to true when cancel() has already emitted Stopped(Cancelled) for this
+    /// turn. The run_turn() outer future checks this to avoid a duplicate Stopped
+    /// when the dropped tx causes rx.await to return Err.
+    stopped_emitted: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 pub struct AcpThread {
@@ -2174,12 +2178,15 @@ impl AcpThread {
 
         self.turn_id += 1;
         let turn_id = self.turn_id;
+        let stopped_emitted = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stopped_emitted_for_task = stopped_emitted.clone();
         self.running_turn = Some(RunningTurn {
             id: turn_id,
             send_task: cx.spawn(async move |this, cx| {
                 cancel_task.await;
                 tx.send(f(this, cx).await).ok();
             }),
+            stopped_emitted,
         });
 
         cx.spawn(async move |this, cx| {
@@ -2205,7 +2212,14 @@ impl AcpThread {
                     if is_same_turn {
                         this.running_turn.take();
                     }
-                    cx.emit(AcpThreadEvent::Stopped(acp::StopReason::Cancelled));
+                    // Only emit Stopped if cancel() hasn't already done so
+                    // synchronously. cancel() emits Stopped before spawning the
+                    // next turn's send_task so that message_completed reaches the
+                    // server before the interrupt's tokens start — preserving FIFO
+                    // ordering. Without this guard the emission would be duplicated.
+                    if !stopped_emitted_for_task.load(std::sync::atomic::Ordering::Acquire) {
+                        cx.emit(AcpThreadEvent::Stopped(acp::StopReason::Cancelled));
+                    }
                     return Ok(None);
                 };
 
@@ -2299,20 +2313,27 @@ impl AcpThread {
         Self::flush_streaming_text(&mut self.streaming_text_buffer, cx);
         self.mark_pending_tools_as_canceled();
 
+        // Emit Stopped(Cancelled) SYNCHRONOUSLY before dropping the send_task.
+        // This guarantees message_completed is sent to the server BEFORE the
+        // next turn's send_task starts generating tokens, preserving the FIFO
+        // ordering expected by the E2E test (and by the server's isolation logic).
+        //
+        // We set stopped_emitted so the run_turn() outer future skips its own
+        // Stopped emission when rx returns Err (which happens because dropping
+        // send_task drops tx, making rx.await return Err). Without this guard
+        // the Stopped event would fire twice: once here and once from run_turn.
+        turn.stopped_emitted.store(true, std::sync::atomic::Ordering::Release);
+        cx.emit(AcpThreadEvent::Stopped(acp::StopReason::Cancelled));
+
         // Drop the send_task instead of awaiting it. This cancels the prompt
         // future immediately, which drops the oneshot `tx`. The `rx.await` in
-        // run_turn then returns Err, hitting the existing "tx dropped" handler
-        // that emits Stopped(Cancelled) (see the `let Ok(response) = response`
-        // branch in run_turn).
+        // run_turn then returns Err — the guard above suppresses the duplicate
+        // Stopped emission from that path.
         //
         // We still call connection.cancel() above as a courtesy notification
         // to the agent. But we don't wait for the agent to acknowledge it —
         // ACP agents that don't properly handle CancelNotification (see
         // claude-agent-acp#442, #423) would block the next turn indefinitely.
-        //
-        // The previous approach was:
-        //   cx.background_spawn(turn.send_task)
-        // which awaited the prompt future to completion before proceeding.
         drop(turn.send_task);
         Task::ready(())
     }

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -1022,21 +1022,51 @@ impl ConversationView {
                                 "📋 [CONV_VIEW] initial_state: registering entity {:?} for session {} (is_resume={})",
                                 entity.entity_id(), session_id, is_resume
                             );
-                            external_websocket_sync::register_thread(session_id.clone(), entity.clone());
 
-                            // When panel restoration resumes a thread, set up the WebSocket
-                            // sync subscription and send agent_ready. Panel restoration
-                            // bypasses the thread_service path (which normally does both),
-                            // so we must do it here. Without agent_ready, the server waits
-                            // 60s before flushing the open_thread/chat_message queue.
                             if is_resume {
-                                external_websocket_sync::ensure_thread_subscription(
-                                    &entity, &session_id, cx,
-                                );
-                                external_websocket_sync::send_agent_ready(
-                                    this.agent.agent_id().0.to_string(),
-                                    Some(session_id),
-                                );
+                                // Try to own the load lock so that open_existing_thread_sync
+                                // waits for us rather than starting a parallel load.
+                                //
+                                // If open_existing_thread_sync already holds the lock for
+                                // THIS thread, it is already loading — skip panel restoration
+                                // entirely so we don't clobber its entity in the registry.
+                                // open_existing_thread_sync's wait-on-lock path will call
+                                // register_thread, ensure_thread_subscription, and send_agent_ready
+                                // once its load completes.
+                                let in_progress = external_websocket_sync::get_load_in_progress_thread();
+                                let other_is_loading_us = in_progress.as_deref() == Some(&session_id);
+
+                                if other_is_loading_us {
+                                    eprintln!(
+                                        "⏭️ [CONV_VIEW] Panel restoration for {} skipped: open_existing_thread_sync already holds the load lock for this thread",
+                                        session_id
+                                    );
+                                    // open_existing_thread_sync will handle register + subscribe + agent_ready.
+                                } else {
+                                    // We win the race (or it's a different thread's load).
+                                    // Acquire lock so open_existing_thread_sync waits for us.
+                                    let lock_acquired = external_websocket_sync::try_acquire_thread_load_lock(&session_id);
+                                    eprintln!(
+                                        "📋 [CONV_VIEW] Panel restoration for {}: lock_acquired={}",
+                                        session_id, lock_acquired
+                                    );
+
+                                    external_websocket_sync::register_thread(session_id.clone(), entity.clone());
+                                    external_websocket_sync::ensure_thread_subscription(
+                                        &entity, &session_id, cx,
+                                    );
+                                    external_websocket_sync::send_agent_ready(
+                                        this.agent.agent_id().0.to_string(),
+                                        Some(session_id.clone()),
+                                    );
+
+                                    if lock_acquired {
+                                        external_websocket_sync::release_thread_load_lock();
+                                    }
+                                }
+                            } else {
+                                // Fresh (non-resumed) thread — just register for routing.
+                                external_websocket_sync::register_thread(session_id.clone(), entity.clone());
                             }
                         }
 

--- a/crates/external_websocket_sync/src/mock_helix_server.rs
+++ b/crates/external_websocket_sync/src/mock_helix_server.rs
@@ -1746,7 +1746,3 @@ mod tests {
         }
     }
 }
-
-entry_type: "text".to_string(),
-                tool_name: String::new(),
-                tool_status: String::new(),

--- a/crates/external_websocket_sync/src/protocol_test.rs
+++ b/crates/external_websocket_sync/src/protocol_test.rs
@@ -445,7 +445,3 @@ mod tests {
     // This would test real ACP thread creation like acp_thread tests do
     // For now, protocol tests + code review provide sufficient confidence
 }
-
-entry_type: "text".to_string(),
-                        tool_name: String::new(),
-                        tool_status: String::new(),

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -86,6 +86,11 @@ pub fn release_thread_load_lock() {
     *loading = None;
 }
 
+/// Returns the thread_id currently held in the load lock, if any.
+pub fn get_load_in_progress_thread() -> Option<String> {
+    THREAD_LOAD_IN_PROGRESS.lock().clone()
+}
+
 /// Streaming throttle state per message entry.
 /// Keyed by "{thread_id}:{entry_idx}" to support multi-entry streaming.
 static STREAMING_THROTTLE: parking_lot::Mutex<Option<Arc<RwLock<HashMap<String, StreamingThrottleState>>>>> =
@@ -1477,13 +1482,62 @@ fn open_existing_thread_sync(
     // async loads race: both pass the registry check above, both spawn load tasks,
     // and the second overwrites the first's entity in the registry — orphaning
     // the first entity's event subscriptions.
+    //
+    // If panel restoration already holds the lock, WAIT for it to finish rather
+    // than skipping — panel restoration registers the entity, and once it releases
+    // the lock we can find the entity via the fast path and just subscribe +
+    // send agent_ready without doing a duplicate load.
     {
         let mut loading = THREAD_LOAD_IN_PROGRESS.lock();
         if let Some(in_progress) = loading.as_ref() {
-            eprintln!("⏳ [THREAD_SERVICE] DUPLICATE LOAD PREVENTED: {} is already loading, skipping load of {}",
+            let in_progress = in_progress.clone();
+            eprintln!("⏳ [THREAD_SERVICE] Load lock held by '{}', waiting for release before handling '{}'",
                       in_progress, request.acp_thread_id);
-            log::warn!("⏳ [THREAD_SERVICE] DUPLICATE LOAD PREVENTED: {} is already loading, skipping load of {}",
+            log::info!("⏳ [THREAD_SERVICE] Load lock held by '{}', waiting for release before handling '{}'",
                        in_progress, request.acp_thread_id);
+            drop(loading); // release parking_lot lock before spawning
+
+            let acp_thread_id = request.acp_thread_id.clone();
+            let agent_name = request.agent_name.clone();
+            cx.spawn(async move |cx| {
+                // Poll until the load lock is released (max 30 s).
+                let deadline = Instant::now() + Duration::from_secs(30);
+                loop {
+                    smol::Timer::after(Duration::from_millis(50)).await;
+                    if THREAD_LOAD_IN_PROGRESS.lock().is_none() {
+                        eprintln!("🔓 [THREAD_SERVICE] Load lock released, rechecking fast path for '{}'", acp_thread_id);
+                        break;
+                    }
+                    if Instant::now() > deadline {
+                        eprintln!("⚠️ [THREAD_SERVICE] Timed out waiting for load lock for '{}', proceeding anyway", acp_thread_id);
+                        break;
+                    }
+                }
+
+                // Recheck registry — whoever held the lock should have registered the entity.
+                if let Some(thread_weak) = get_thread(&acp_thread_id) {
+                    if let Some(thread_entity) = thread_weak.upgrade() {
+                        let flag_was_set = {
+                            let subs = PERSISTENT_SUBSCRIPTIONS.lock();
+                            subs.as_ref().map(|s| s.read().contains(&acp_thread_id)).unwrap_or(false)
+                        };
+                        let entity_id = thread_entity.entity_id();
+                        eprintln!(
+                            "🔍 [THREAD_SERVICE] After lock wait: fast-path entity={:?}, subscription flag was_set={} for '{}'",
+                            entity_id, flag_was_set, acp_thread_id
+                        );
+                        cx.update(|cx| {
+                            ensure_thread_subscription(&thread_entity, &acp_thread_id, cx);
+                        });
+                    }
+                    let agent_name_for_ready = agent_name.unwrap_or_else(|| "zed-agent".to_string());
+                    eprintln!("🚀 [THREAD_SERVICE] Sending agent_ready after lock-wait for '{}'", acp_thread_id);
+                    crate::send_agent_ready(agent_name_for_ready, Some(acp_thread_id));
+                } else {
+                    eprintln!("⚠️ [THREAD_SERVICE] Lock released but entity not in registry for '{}' — no action taken", acp_thread_id);
+                    log::warn!("⚠️ [THREAD_SERVICE] Lock released but entity not in registry for '{}'", acp_thread_id);
+                }
+            }).detach();
             return Ok(());
         }
         eprintln!("🔒 [THREAD_SERVICE] Acquired thread load lock for {}", request.acp_thread_id);
@@ -1632,10 +1686,25 @@ fn open_existing_thread_sync(
         // the panel-restoration entity while we registered a brand-new entity from
         // load_session — events on the new entity are never forwarded to Helix.
         {
+            let flag_was_set = {
+                let subs = PERSISTENT_SUBSCRIPTIONS.lock();
+                subs.as_ref().map(|s| s.read().contains(&acp_thread_id)).unwrap_or(false)
+            };
+            let load_session_entity_id = thread_entity.entity_id();
+            eprintln!(
+                "🔍 [THREAD_SERVICE] open_existing_thread_sync slow path: subscription flag was_set={}, load_session entity={:?} for '{}'",
+                flag_was_set, load_session_entity_id, acp_thread_id
+            );
+            log::info!(
+                "🔍 [THREAD_SERVICE] open_existing_thread_sync slow path: subscription flag was_set={}, load_session entity={:?} for '{}'",
+                flag_was_set, load_session_entity_id, acp_thread_id
+            );
+            // Clear any stale flag from a racing panel restoration that used a
+            // different entity before load_session completed here.
             let subs = PERSISTENT_SUBSCRIPTIONS.lock();
             if let Some(s) = subs.as_ref() {
                 if s.write().remove(&acp_thread_id) {
-                    eprintln!("🔄 [THREAD_SERVICE] Cleared stale subscription flag for '{}' (panel restoration used a different entity)", acp_thread_id);
+                    eprintln!("🔄 [THREAD_SERVICE] Cleared stale subscription flag for '{}' (was set on a different entity)", acp_thread_id);
                     log::info!("🔄 [THREAD_SERVICE] Cleared stale subscription flag for '{}' before re-subscribing on load_session entity", acp_thread_id);
                 }
             }

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -528,6 +528,14 @@ pub fn ensure_thread_subscription(
     let turn_request_id: std::cell::RefCell<String> = std::cell::RefCell::new(
         crate::get_thread_request_id(thread_id).unwrap_or_default()
     );
+    // Tracks the last request_id for which message_completed was already sent.
+    // When Stopped fires for a turn that produced no assistant entries (e.g. the
+    // interrupt turn is immediately cancelled by Claude Code before generating
+    // any tokens), turn_request_id is never updated by NewEntry and still holds
+    // the previous turn's id. Detecting this via last_completed_request_id lets
+    // us fall back to the global THREAD_REQUEST_MAP which already points to the
+    // new turn's request_id.
+    let last_completed_request_id: std::cell::RefCell<String> = std::cell::RefCell::new(String::new());
 
     let sub_entity_id = entity_id;
     cx.subscribe(thread_entity, move |thread_entity, event, cx| {
@@ -717,8 +725,27 @@ pub fn ensure_thread_subscription(
                     }
                 }
 
-                // Use the turn's captured request_id for message_completed too
-                let completed_rid = turn_request_id.borrow().clone();
+                // Use the turn's captured request_id for message_completed.
+                // FALLBACK: if turn_request_id still holds the previous turn's id
+                // (because no assistant NewEntry fired to update it — happens when
+                // the interrupt turn is immediately cancelled with no output), use
+                // the current global THREAD_REQUEST_MAP which points to this turn.
+                let captured_rid = turn_request_id.borrow().clone();
+                let last_completed = last_completed_request_id.borrow().clone();
+                let completed_rid = if !captured_rid.is_empty() && captured_rid == last_completed {
+                    // turn_request_id is stale — the previous turn already used it.
+                    // Use the global map which has the current turn's request_id.
+                    let fallback = crate::get_thread_request_id(&thread_id_for_sub)
+                        .unwrap_or_else(|| captured_rid.clone());
+                    eprintln!(
+                        "📤 [THREAD_SERVICE] Stopped: turn_request_id={} already used, falling back to global={}",
+                        captured_rid, fallback
+                    );
+                    fallback
+                } else {
+                    captured_rid
+                };
+                *last_completed_request_id.borrow_mut() = completed_rid.clone();
                 eprintln!(
                     "📤 [THREAD_SERVICE] Stopped event: sending message_completed for thread {} (request_id={})",
                     thread_id_for_sub, completed_rid

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -1624,6 +1624,22 @@ fn open_existing_thread_sync(
         // after a Zed restart the thread loads successfully but its NewEntry /
         // EntryUpdated / Stopped events have no listener, so message_added is
         // never emitted and the interaction stays stuck in "waiting" forever.
+        //
+        // We MUST clear the persistent-subscription flag first.  Panel restoration
+        // may have already called ensure_thread_subscription on a *different* entity
+        // (the one it created before load_session ran here), setting the flag.
+        // If we skip the call because the flag is set, the subscription stays on
+        // the panel-restoration entity while we registered a brand-new entity from
+        // load_session — events on the new entity are never forwarded to Helix.
+        {
+            let subs = PERSISTENT_SUBSCRIPTIONS.lock();
+            if let Some(s) = subs.as_ref() {
+                if s.write().remove(&acp_thread_id) {
+                    eprintln!("🔄 [THREAD_SERVICE] Cleared stale subscription flag for '{}' (panel restoration used a different entity)", acp_thread_id);
+                    log::info!("🔄 [THREAD_SERVICE] Cleared stale subscription flag for '{}' before re-subscribing on load_session entity", acp_thread_id);
+                }
+            }
+        }
         cx.update(|cx| {
             ensure_thread_subscription(&thread_entity, &acp_thread_id, cx);
         });


### PR DESCRIPTION
## Summary

Fixes two categories of bugs: Zed reconnect/restart subscription stability, and ZE2E phase 8 interrupt ordering.

### Zed restart / reconnect fixes

**Fix stale subscription flag blocking reconnect (`22f94a8b`)**: After Zed restarts and reconnects, `open_existing_thread_sync` re-subscribes to threads. But if the previous session had set `has_persistent_subscription`, the flag was never cleared, so `ensure_thread_subscription` skipped creating a new subscription on the fresh entity — leaving the reconnected session with no event subscription and no WebSocket sync. Fix: clear the flag before re-subscribing.

**Coordinate panel restoration and `open_existing_thread_sync` via load lock (`d470dac6`)**: Panel restoration and `open_existing_thread_sync` could race on reconnect, causing duplicate thread loads or missed subscriptions. Fix: share the thread load lock between both code paths so they're serialized.

**Remove orphaned struct fields from bad merge (`28c48a25`)**: Cleanup leftover fields introduced by a bad merge.

### ZE2E phase 8 fix: mid-stream interrupt FIFO ordering (`90bdb6c`)

Two races caused phase 8 (mid-stream interrupt) to fail intermittently for both agents:

**Ordering violation (both agents)**: `cancel()` dropped `send_task` asynchronously, so the interrupt's new turn could start generating tokens before the cancelled turn emitted `Stopped(Cancelled)` and sent `message_completed` to the server. Fix: emit `Stopped(Cancelled)` **synchronously** in `cancel()` before dropping `send_task`. Add `stopped_emitted: AtomicBool` to `RunningTurn` so the outer future's rx-Err path skips the duplicate.

**Wrong request_id in `message_completed` (claude agent)**: when the interrupt turn was immediately cancelled by Claude Code with no output, no `NewEntry` events fired to update `turn_request_id` in the subscription closure, so both Stopped events used the initial turn's request_id. Fix: track `last_completed_request_id`; when Stopped fires and the id equals the last-sent one, fall back to `get_thread_request_id()`.

## Test plan
- [x] ZE2E `E2E_AGENTS="zed-agent,claude"` passes all 12 phases including phase 8 (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)