### PR TITLE
fix: implement real interrupt via dedicated cancel task

### DIFF
--- a/crates/external_websocket_sync/src/external_websocket_sync.rs
+++ b/crates/external_websocket_sync/src/external_websocket_sync.rs
@@ -92,6 +92,12 @@ static GLOBAL_THREAD_OPEN_CALLBACK: parking_lot::Mutex<Option<mpsc::UnboundedSen
 static GLOBAL_UI_STATE_QUERY_CALLBACK: parking_lot::Mutex<Option<mpsc::UnboundedSender<UiStateQueryRequest>>> =
     parking_lot::Mutex::new(None);
 
+/// Static global for cancel-thread callback.
+/// Receives an acp_thread_id and immediately cancels that thread's running turn,
+/// bypassing the sequential callback_rx loop (which would be blocked awaiting the turn).
+static GLOBAL_CANCEL_THREAD_CALLBACK: parking_lot::Mutex<Option<mpsc::UnboundedSender<String>>> =
+    parking_lot::Mutex::new(None);
+
 /// Pending UI state queries that arrived before AgentPanel was ready
 static PENDING_UI_STATE_QUERIES: parking_lot::Mutex<Vec<UiStateQueryRequest>> =
     parking_lot::Mutex::new(Vec::new());
@@ -849,6 +855,35 @@ pub fn subscribe_to_context_changes_global(context: Entity<TextThread>, external
     // Store the subscription in global state so it doesn't get dropped
     // TODO: We need a way to store these subscriptions globally
     eprintln!("✅ [SYNC_GLOBAL] Context subscription created for session: {}", external_session_id);
+}
+
+/// Request that the currently running turn on a thread be cancelled immediately.
+/// This bypasses the sequential callback_rx loop (which blocks waiting for turn
+/// completion) by routing through a dedicated cancel GPUI task.
+/// Called when Helix sends a chat_message with interrupt=true.
+pub fn request_cancel_thread(acp_thread_id: String) -> Result<()> {
+    eprintln!("⚡ [CANCEL] request_cancel_thread() called for thread: {}", acp_thread_id);
+    log::info!("⚡ [CANCEL] request_cancel_thread() called for thread: {}", acp_thread_id);
+
+    let sender = GLOBAL_CANCEL_THREAD_CALLBACK.lock().clone();
+    if let Some(sender) = sender {
+        sender.send(acp_thread_id)
+            .map_err(|_| anyhow::anyhow!("Failed to send cancel request"))?;
+        Ok(())
+    } else {
+        // Cancel task not yet initialized — log and ignore. The new message will
+        // be processed sequentially as before (no worse than the old behaviour).
+        eprintln!("⚠️ [CANCEL] Cancel callback not yet initialized, skipping cancel for thread: {}", acp_thread_id);
+        log::warn!("⚠️ [CANCEL] Cancel callback not yet initialized, skipping cancel for thread: {}", acp_thread_id);
+        Ok(())
+    }
+}
+
+/// Initialize the global cancel-thread callback (called from thread_service).
+pub fn init_cancel_thread_callback(sender: mpsc::UnboundedSender<String>) {
+    eprintln!("🔧 [CANCEL] init_cancel_thread_callback() called - registering global callback");
+    log::info!("🔧 [CANCEL] init_cancel_thread_callback() called - registering global callback");
+    *GLOBAL_CANCEL_THREAD_CALLBACK.lock() = Some(sender);
 }
 
 

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -798,6 +798,37 @@ pub fn setup_thread_handler(
     let acp_history_store_for_open = acp_history_store.clone();
     let fs_for_open = fs.clone();
 
+    // Spawn dedicated cancel task — runs independently of the callback_rx loop so it
+    // can cancel a running turn even while callback_rx.recv().await is blocked.
+    let (cancel_tx, mut cancel_rx) = mpsc::unbounded_channel::<String>();
+    crate::init_cancel_thread_callback(cancel_tx);
+    cx.spawn(async move |cx| {
+        eprintln!("⚡ [CANCEL_TASK] Cancel task started, waiting for cancel requests...");
+        log::info!("⚡ [CANCEL_TASK] Cancel task started, waiting for cancel requests...");
+        while let Some(acp_thread_id) = cancel_rx.recv().await {
+            eprintln!("⚡ [CANCEL_TASK] Received cancel request for thread: {}", acp_thread_id);
+            log::info!("⚡ [CANCEL_TASK] Received cancel request for thread: {}", acp_thread_id);
+            if let Some(thread) = crate::get_thread(&acp_thread_id) {
+                let result = cx.update(|cx| {
+                    thread.update(cx, |t, cx| { t.cancel(cx) })
+                });
+                match result {
+                    Ok(_) => {
+                        eprintln!("✅ [CANCEL_TASK] Cancelled running turn on thread: {}", acp_thread_id);
+                        log::info!("✅ [CANCEL_TASK] Cancelled running turn on thread: {}", acp_thread_id);
+                    }
+                    Err(e) => {
+                        eprintln!("⚠️ [CANCEL_TASK] Failed to cancel thread {}: {}", acp_thread_id, e);
+                        log::warn!("⚠️ [CANCEL_TASK] Failed to cancel thread {}: {}", acp_thread_id, e);
+                    }
+                }
+            } else {
+                eprintln!("⚠️ [CANCEL_TASK] Thread {} not found in registry, skipping cancel", acp_thread_id);
+                log::warn!("⚠️ [CANCEL_TASK] Thread {} not found in registry, skipping cancel", acp_thread_id);
+            }
+        }
+    }).detach();
+
     // Spawn handler task to process thread creation requests
     cx.spawn(async move |cx| {
         eprintln!("🔧 [THREAD_SERVICE] Handler task started, waiting for requests...");

--- a/crates/external_websocket_sync/src/types.rs
+++ b/crates/external_websocket_sync/src/types.rs
@@ -343,6 +343,8 @@ pub struct IncomingChatMessage {
     pub session_id: Option<String>,  // Optional session_id field from API (can be ignored)
     #[serde(default)]
     pub agent_name: Option<String>,  // Which agent to use (zed-agent or qwen) - defaults to zed-agent
+    #[serde(default)]
+    pub interrupt: bool,  // If true, cancel the current running turn before sending this message
 }
 
 /// Response for health check endpoint

--- a/crates/external_websocket_sync/src/websocket_sync.rs
+++ b/crates/external_websocket_sync/src/websocket_sync.rs
@@ -423,10 +423,27 @@ impl WebSocketSync {
             return Ok(());
         }
 
-        eprintln!("💬 [WEBSOCKET-IN] Processing chat_message: acp_thread_id={:?}, request_id={}, message_len={}",
-                   chat_msg.acp_thread_id, chat_msg.request_id, chat_msg.message.len());
-        log::info!("💬 [WEBSOCKET-IN] Processing chat_message: acp_thread_id={:?}, request_id={}, message_len={}",
-                   chat_msg.acp_thread_id, chat_msg.request_id, chat_msg.message.len());
+        eprintln!("💬 [WEBSOCKET-IN] Processing chat_message: acp_thread_id={:?}, request_id={}, message_len={}, interrupt={}",
+                   chat_msg.acp_thread_id, chat_msg.request_id, chat_msg.message.len(), chat_msg.interrupt);
+        log::info!("💬 [WEBSOCKET-IN] Processing chat_message: acp_thread_id={:?}, request_id={}, message_len={}, interrupt={}",
+                   chat_msg.acp_thread_id, chat_msg.request_id, chat_msg.message.len(), chat_msg.interrupt);
+
+        // If this is an interrupt message and we have an existing thread, cancel its
+        // running turn immediately via the dedicated cancel task (which runs independently
+        // of the sequential callback_rx loop, so it can fire even while the loop is
+        // blocked awaiting the previous turn's response).
+        if chat_msg.interrupt {
+            if let Some(ref thread_id) = chat_msg.acp_thread_id {
+                if !thread_id.is_empty() {
+                    eprintln!("⚡ [WEBSOCKET-IN] Interrupt flag set — cancelling running turn on thread: {}", thread_id);
+                    log::info!("⚡ [WEBSOCKET-IN] Interrupt flag set — cancelling running turn on thread: {}", thread_id);
+                    if let Err(e) = crate::request_cancel_thread(thread_id.clone()) {
+                        eprintln!("⚠️ [WEBSOCKET-IN] Failed to request cancel for thread {}: {}", thread_id, e);
+                        log::warn!("⚠️ [WEBSOCKET-IN] Failed to request cancel for thread {}: {}", thread_id, e);
+                    }
+                }
+            }
+        }
 
         // Request thread creation via callback
         let request = ThreadCreationRequest {


### PR DESCRIPTION
## Summary

- Interrupts sent from Helix were silently queued behind the current turn instead of cancelling it
- The `callback_rx` loop blocks on `handle_follow_up_message(...).await` while the LLM responds, so interrupt messages sit in the channel until the turn finishes naturally — making the "interrupt" a no-op
- The UI stop button works because it calls `thread.cancel(cx)` directly, bypassing the queue entirely

This PR implements the same stop-button path for Helix-initiated interrupts:
- Add `interrupt: bool` field to `IncomingChatMessage`
- Add a dedicated cancel GPUI task (separate from `callback_rx` loop) that receives an `acp_thread_id` and immediately calls `thread.cancel(cx)`
- In `handle_chat_message`, when `interrupt=true`, fire `request_cancel_thread()` before queuing the new message

The cancel drops the running `send_task`, unblocking the `callback_rx` loop's `send_task.await` with `Err`. The interrupt message is then processed as the next sequential turn.

## Why the E2E phase 8 test didn't catch this

Phase 8 counts 2 `message_completed` events and checks ordering. Both conditions are trivially satisfied by sequential processing (turn 1 finishes → completion 1, then interrupt processes → completion 2). The test never verified that the first turn was actually *cancelled* mid-stream.

## Test plan

- [ ] Rebuild Zed binary and run ZE2E test — phase 8 should now produce a cancelled first turn (short/empty response) + interrupt response
- [ ] Test in production: send an interrupt while agent is mid-tool-use; it should stop promptly rather than completing the full turn first

🤖 Generated with [Claude Code](https://claude.com/claude-code)