### PR TITLE
Auto-approve ACP permission requests for Helix autonomous mode

### DIFF
--- a/crates/agent_servers/Cargo.toml
+++ b/crates/agent_servers/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0-or-later"
 [features]
 test-support = ["acp_thread/test-support", "gpui/test-support", "project/test-support", "dep:env_logger", "client/test-support", "dep:gpui_tokio", "reqwest_client/test-support"]
 e2e = []
+external_websocket_sync = []
 
 [lints]
 workspace = true

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -1449,6 +1449,29 @@ impl acp::Client for ClientDelegate {
         &self,
         arguments: acp::RequestPermissionRequest,
     ) -> Result<acp::RequestPermissionResponse, acp::Error> {
+        #[cfg(feature = "external_websocket_sync")]
+        {
+            let option = arguments
+                .options
+                .iter()
+                .find(|o| o.kind == acp::PermissionOptionKind::AllowOnce)
+                .or_else(|| {
+                    arguments
+                        .options
+                        .iter()
+                        .find(|o| o.kind == acp::PermissionOptionKind::AllowAlways)
+                })
+                .or_else(|| arguments.options.first());
+
+            if let Some(option) = option {
+                return Ok(acp::RequestPermissionResponse::new(
+                    acp::RequestPermissionOutcome::Selected(
+                        acp::SelectedPermissionOutcome::new(option.option_id.clone()),
+                    ),
+                ));
+            }
+        }
+
         let thread;
         {
             let sessions_ref = self.sessions.borrow();

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [features]
 tracy = ["ztracing/tracy"]
-external_websocket_sync = ["agent_ui/external_websocket_sync", "dep:external_websocket_sync", "title_bar/external_websocket_sync"]
+external_websocket_sync = ["agent_ui/external_websocket_sync", "dep:external_websocket_sync", "title_bar/external_websocket_sync", "agent_servers/external_websocket_sync"]
 test-support = [
     "gpui/test-support",
     "gpui_platform/screen-capture",


### PR DESCRIPTION
## Summary
When running as a Helix spectask (with `external_websocket_sync` feature enabled), ACP permission requests — including plan mode exit confirmations — are auto-approved so sessions run autonomously without user interaction.

## Changes
- Add `#[cfg(feature = "external_websocket_sync")]` block in `ClientDelegate::request_permission()` (`crates/agent_servers/src/acp.rs`) that selects the first AllowOnce option and returns immediately, bypassing the UI permission flow
- Add `external_websocket_sync` feature to `crates/agent_servers/Cargo.toml`
- Propagate feature from `crates/zed/Cargo.toml`

Release Notes:

- N/A

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kp6yp1ek1p976kdbvmd0baa3)

📋 Spec:
- [Requirements](https://github.com/helixml/zed/blob/helix-specs/design/tasks/001807_when-claude-code-acp/requirements.md)
- [Design](https://github.com/helixml/zed/blob/helix-specs/design/tasks/001807_when-claude-code-acp/design.md)
- [Tasks](https://github.com/helixml/zed/blob/helix-specs/design/tasks/001807_when-claude-code-acp/tasks.md)

🚀 Built with [Helix](https://helix.ml)