### PR TITLE
external_websocket_sync: refresh turn_request_id on UserMessage NewEntry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "action_log",
  "agent-client-protocol",
  "anyhow",
+ "async-channel 2.5.0",
  "base64 0.22.1",
  "buffer_diff",
  "chrono",
@@ -34,7 +35,6 @@ dependencies = [
  "serde",
  "serde_json",
  "settings",
- "smol",
  "task",
  "telemetry",
  "terminal",
@@ -52,16 +52,16 @@ name = "acp_tools"
 version = "0.1.0"
 dependencies = [
  "agent-client-protocol",
+ "agent_servers",
+ "agent_ui",
  "collections",
  "gpui",
  "language",
- "log",
  "markdown",
  "project",
  "serde",
  "serde_json",
  "settings",
- "smol",
  "theme_settings",
  "ui",
  "util",
@@ -152,6 +152,8 @@ dependencies = [
  "agent_servers",
  "agent_settings",
  "anyhow",
+ "async-channel 2.5.0",
+ "async-io",
  "chrono",
  "client",
  "clock",
@@ -198,7 +200,6 @@ dependencies = [
  "settings",
  "shell_command_parser",
  "smallvec",
- "smol",
  "sqlez",
  "streaming_diff",
  "strsim",
@@ -276,10 +277,10 @@ name = "agent_servers"
 version = "0.1.0"
 dependencies = [
  "acp_thread",
- "acp_tools",
  "action_log",
  "agent-client-protocol",
  "anyhow",
+ "async-channel 2.5.0",
  "chrono",
  "client",
  "collections",
@@ -303,7 +304,6 @@ dependencies = [
  "serde",
  "serde_json",
  "settings",
- "smol",
  "task",
  "tempfile",
  "terminal",
@@ -351,6 +351,7 @@ dependencies = [
  "agent_settings",
  "ai_onboarding",
  "anyhow",
+ "async-channel 2.5.0",
  "audio",
  "base64 0.22.1",
  "buffer_diff",
@@ -399,6 +400,7 @@ dependencies = [
  "parking_lot",
  "paths",
  "picker",
+ "platform_title_bar",
  "postage",
  "pretty_assertions",
  "project",
@@ -419,7 +421,6 @@ dependencies = [
  "serde_json",
  "serde_json_lenient",
  "settings",
- "smol",
  "streaming_diff",
  "task",
  "telemetry",
@@ -937,7 +938,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
 dependencies = [
- "async-lock 3.4.2",
+ "async-lock",
  "blocking",
  "futures-lite 2.6.1",
 ]
@@ -951,7 +952,7 @@ dependencies = [
  "async-channel 2.5.0",
  "async-executor",
  "async-io",
- "async-lock 3.4.2",
+ "async-lock",
  "blocking",
  "futures-lite 2.6.1",
  "once_cell",
@@ -973,15 +974,6 @@ dependencies = [
  "rustix 1.1.2",
  "slab",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -1023,7 +1015,7 @@ checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
  "async-channel 2.5.0",
  "async-io",
- "async-lock 3.4.2",
+ "async-lock",
  "async-signal",
  "async-task",
  "blocking",
@@ -1051,7 +1043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
 dependencies = [
  "async-io",
- "async-lock 3.4.2",
+ "async-lock",
  "atomic-waker",
  "cfg-if",
  "futures-core",
@@ -1072,7 +1064,7 @@ dependencies = [
  "async-channel 1.9.0",
  "async-global-executor",
  "async-io",
- "async-lock 3.4.2",
+ "async-lock",
  "async-process",
  "crossbeam-utils",
  "futures-channel",
@@ -1296,10 +1288,12 @@ dependencies = [
  "gpui",
  "markdown_preview",
  "notifications",
+ "project",
  "release_channel",
  "semver",
  "serde",
  "serde_json",
+ "settings",
  "smol",
  "telemetry",
  "ui",
@@ -3020,6 +3014,7 @@ name = "client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-channel 2.5.0",
  "async-tungstenite",
  "base64 0.22.1",
  "chrono",
@@ -3087,6 +3082,7 @@ name = "cloud_api_client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-lock",
  "cloud_api_types",
  "futures 0.3.32",
  "gpui",
@@ -3094,7 +3090,6 @@ dependencies = [
  "http_client",
  "parking_lot",
  "serde_json",
- "smol",
  "thiserror 2.0.17",
  "yawc",
 ]
@@ -3241,6 +3236,7 @@ version = "0.44.0"
 dependencies = [
  "agent",
  "anyhow",
+ "async-channel 2.5.0",
  "async-trait",
  "async-tungstenite",
  "aws-config",
@@ -3618,15 +3614,19 @@ name = "context_server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-channel 2.5.0",
+ "async-process",
  "async-trait",
  "base64 0.22.1",
  "collections",
  "futures 0.3.32",
+ "futures-lite 1.13.0",
  "gpui",
  "http_client",
  "log",
  "net",
  "parking_lot",
+ "pollster 0.4.0",
  "postage",
  "rand 0.9.3",
  "schemars 1.0.4",
@@ -3635,7 +3635,6 @@ dependencies = [
  "settings",
  "sha2",
  "slotmap",
- "smol",
  "tempfile",
  "tiny_http",
  "url",
@@ -4172,6 +4171,7 @@ dependencies = [
 name = "crashes"
 version = "0.1.0"
 dependencies = [
+ "async-process",
  "cfg-if",
  "crash-handler",
  "futures 0.3.32",
@@ -4183,7 +4183,6 @@ dependencies = [
  "release_channel",
  "serde",
  "serde_json",
- "smol",
  "system_specs",
  "windows 0.61.3",
  "zstd",
@@ -4715,7 +4714,6 @@ dependencies = [
  "log",
  "paths",
  "release_channel",
- "smol",
  "sqlez",
  "sqlez_macros",
  "tempfile",
@@ -5534,6 +5532,7 @@ dependencies = [
  "file_icons",
  "fs",
  "futures 0.3.32",
+ "futures-lite 1.13.0",
  "fuzzy",
  "git",
  "gpui",
@@ -5564,7 +5563,6 @@ dependencies = [
  "serde_json",
  "settings",
  "smallvec",
- "smol",
  "snippet",
  "sum_tree",
  "task",
@@ -6419,6 +6417,7 @@ dependencies = [
  "theme",
  "theme_settings",
  "ui",
+ "ui_input",
  "util",
  "workspace",
  "zed_actions",
@@ -6699,6 +6698,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ashpd",
+ "async-channel 2.5.0",
  "async-tar",
  "async-trait",
  "collections",
@@ -7376,6 +7376,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "askpass",
+ "async-channel 2.5.0",
  "async-trait",
  "collections",
  "derive_more",
@@ -7425,6 +7426,7 @@ name = "git_graph"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-channel 2.5.0",
  "collections",
  "db",
  "editor",
@@ -7433,15 +7435,16 @@ dependencies = [
  "git_ui",
  "gpui",
  "language",
+ "language_model",
  "menu",
  "project",
+ "project_panel",
  "rand 0.9.3",
  "remote_connection",
  "search",
  "serde_json",
  "settings",
  "smallvec",
- "smol",
  "theme",
  "theme_settings",
  "time",
@@ -7489,6 +7492,7 @@ dependencies = [
  "file_icons",
  "fs",
  "futures 0.3.32",
+ "futures-lite 1.13.0",
  "fuzzy",
  "fuzzy_nucleo",
  "git",
@@ -7517,7 +7521,6 @@ dependencies = [
  "serde_json",
  "settings",
  "smallvec",
- "smol",
  "strum 0.27.2",
  "task",
  "telemetry",
@@ -7947,10 +7950,9 @@ dependencies = [
 name = "gpui_shared_string"
 version = "0.1.0"
 dependencies = [
- "derive_more",
- "gpui_util",
  "schemars 1.0.4",
  "serde",
+ "smol_str",
 ]
 
 [[package]]
@@ -8077,9 +8079,9 @@ dependencies = [
 
 [[package]]
 name = "grid"
-version = "0.18.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12101ecc8225ea6d675bc70263074eab6169079621c2186fe0c66590b2df9681"
+checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "group"
@@ -9591,6 +9593,7 @@ dependencies = [
  "encoding_rs",
  "fs",
  "futures 0.3.32",
+ "futures-lite 1.13.0",
  "fuzzy",
  "globset",
  "gpui",
@@ -9613,7 +9616,6 @@ dependencies = [
  "settings",
  "shellexpand",
  "smallvec",
- "smol",
  "streaming-iterator",
  "strsim",
  "sum_tree",
@@ -9711,6 +9713,7 @@ name = "language_model_core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-lock",
  "cloud_llm_client",
  "futures 0.3.32",
  "gpui_shared_string",
@@ -9719,7 +9722,6 @@ dependencies = [
  "schemars 1.0.4",
  "serde",
  "serde_json",
- "smol",
  "strum 0.27.2",
  "thiserror 2.0.17",
 ]
@@ -9731,6 +9733,7 @@ dependencies = [
  "ai_onboarding",
  "anthropic",
  "anyhow",
+ "async-lock",
  "aws-config",
  "aws-credential-types",
  "aws_http_client",
@@ -9772,7 +9775,6 @@ dependencies = [
  "serde",
  "serde_json",
  "settings",
- "smol",
  "strum 0.27.2",
  "tokio",
  "ui",
@@ -9799,7 +9801,6 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "smol",
  "thiserror 2.0.17",
 ]
 
@@ -10557,6 +10558,7 @@ dependencies = [
  "project",
  "settings",
  "tempfile",
+ "theme",
  "theme_settings",
  "ui",
  "urlencoding",
@@ -10913,9 +10915,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 name = "miniprofiler_ui"
 version = "0.1.0"
 dependencies = [
+ "command_palette_hooks",
  "gpui",
  "rpc",
  "serde_json",
+ "settings",
  "smol",
  "theme_settings",
  "util",
@@ -11025,6 +11029,7 @@ dependencies = [
  "clock",
  "collections",
  "ctor",
+ "futures-lite 1.13.0",
  "gpui",
  "indoc",
  "itertools 0.14.0",
@@ -11037,7 +11042,6 @@ dependencies = [
  "serde",
  "settings",
  "smallvec",
- "smol",
  "sum_tree",
  "text",
  "theme",
@@ -11311,7 +11315,7 @@ dependencies = [
  "channel",
  "client",
  "component",
- "db",
+ "futures-lite 1.13.0",
  "gpui",
  "rpc",
  "sum_tree",
@@ -11905,7 +11909,7 @@ dependencies = [
  "ashpd",
  "async-fs",
  "async-io",
- "async-lock 3.4.2",
+ "async-lock",
  "blocking",
  "cbc",
  "cipher",
@@ -12148,6 +12152,7 @@ name = "outline"
 version = "0.1.0"
 dependencies = [
  "editor",
+ "futures 0.3.32",
  "fuzzy",
  "gpui",
  "indoc",
@@ -12160,7 +12165,6 @@ dependencies = [
  "rope",
  "serde_json",
  "settings",
- "smol",
  "theme",
  "theme_settings",
  "ui",
@@ -12174,10 +12178,12 @@ name = "outline_panel"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-channel 2.5.0",
  "collections",
  "db",
  "editor",
  "file_icons",
+ "futures 0.3.32",
  "fuzzy",
  "gpui",
  "itertools 0.14.0",
@@ -12193,7 +12199,6 @@ dependencies = [
  "serde_json",
  "settings",
  "smallvec",
- "smol",
  "theme",
  "theme_settings",
  "ui",
@@ -13553,6 +13558,7 @@ dependencies = [
  "aho-corasick",
  "anyhow",
  "askpass",
+ "async-channel 2.5.0",
  "async-trait",
  "base64 0.22.1",
  "buffer_diff",
@@ -14517,7 +14523,6 @@ dependencies = [
  "serde",
  "serde_json",
  "settings",
- "smol",
  "task",
  "telemetry",
  "ui",
@@ -14719,6 +14724,7 @@ dependencies = [
  "agent",
  "anyhow",
  "askpass",
+ "async-channel 2.5.0",
  "cargo_toml",
  "clap",
  "client",
@@ -15857,6 +15863,7 @@ dependencies = [
  "editor",
  "fs",
  "futures 0.3.32",
+ "futures-lite 1.13.0",
  "gpui",
  "itertools 0.14.0",
  "language",
@@ -15868,7 +15875,6 @@ dependencies = [
  "serde",
  "serde_json",
  "settings",
- "smol",
  "theme",
  "theme_settings",
  "tracing",
@@ -16417,6 +16423,7 @@ dependencies = [
  "agent_settings",
  "agent_ui",
  "anyhow",
+ "async-channel 2.5.0",
  "chrono",
  "client",
  "clock",
@@ -16446,7 +16453,6 @@ dependencies = [
  "serde",
  "serde_json",
  "settings",
- "smol",
  "telemetry",
  "theme",
  "theme_settings",
@@ -16631,7 +16637,7 @@ dependencies = [
  "async-executor",
  "async-fs",
  "async-io",
- "async-lock 3.4.2",
+ "async-lock",
  "async-net",
  "async-process",
  "blocking",
@@ -16640,9 +16646,13 @@ dependencies = [
 
 [[package]]
 name = "smol_str"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f7a918bd2a9951d18ee6e48f076843e8e73a9a5d22cf05bcd4b7a81bdd04e17"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
 
 [[package]]
 name = "snafu"
@@ -16798,7 +16808,7 @@ dependencies = [
  "libsqlite3-sys",
  "log",
  "parking_lot",
- "smol",
+ "pollster 0.4.0",
  "sqlformat",
  "thread_local",
  "util",
@@ -17729,9 +17739,9 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13e5d13f79d558b5d353a98072ca8ca0e99da429467804de959aa8c83c9a004"
+checksum = "aea22054047c16c3f34d3ac473a2170be1424b1115b2a3adcf28cfb067c88859"
 dependencies = [
  "arrayvec",
  "grid",
@@ -17882,20 +17892,22 @@ version = "0.1.0"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
+ "async-channel 2.5.0",
  "collections",
  "futures 0.3.32",
+ "futures-lite 1.13.0",
  "gpui",
  "itertools 0.14.0",
  "libc",
  "log",
  "parking_lot",
+ "percent-encoding",
  "rand 0.9.3",
  "regex",
  "release_channel",
  "schemars 1.0.4",
  "serde",
  "settings",
- "smol",
  "sysinfo 0.37.2",
  "task",
  "theme",
@@ -18267,6 +18279,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 name = "title_bar"
 version = "0.1.0"
 dependencies = [
+ "agent_settings",
  "anyhow",
  "arrayvec",
  "auto_update",
@@ -18278,6 +18291,7 @@ dependencies = [
  "db",
  "external_websocket_sync",
  "feature_flags",
+ "fs",
  "git_ui",
  "gpui",
  "icons",
@@ -22124,6 +22138,7 @@ dependencies = [
  "db",
  "fs",
  "futures 0.3.32",
+ "futures-lite 1.13.0",
  "git",
  "gpui",
  "http_client",
@@ -22166,7 +22181,8 @@ name = "worktree"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-lock 2.8.0",
+ "async-channel 2.5.0",
+ "async-lock",
  "chardetng",
  "clock",
  "collections",
@@ -22189,7 +22205,6 @@ dependencies = [
  "serde_json",
  "settings",
  "smallvec",
- "smol",
  "sum_tree",
  "text",
  "tracing",
@@ -22526,7 +22541,7 @@ dependencies = [
  "async-broadcast",
  "async-executor",
  "async-io",
- "async-lock 3.4.2",
+ "async-lock",
  "async-process",
  "async-recursion",
  "async-task",

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -684,6 +684,35 @@ pub fn ensure_thread_subscription(
                         }
                         _ => (String::new(), String::new()),
                     };
+                    // A new UserMessage entry is the unambiguous start of a
+                    // new turn — force-rotate turn_request_id from the global
+                    // map regardless of whether the previous turn completed
+                    // cleanly. The chat_message handler updates
+                    // THREAD_REQUEST_MAP when the user's prompt arrives, so by
+                    // the time NewEntry fires for the UserMessage the global
+                    // map already holds the new turn's id.
+                    //
+                    // Without this, an interrupted/cancelled prior turn leaves
+                    // last_completed_request_id stale, the assistant-only
+                    // rotation below never fires, and every assistant entry
+                    // (including the re-emit loop further down) carries the
+                    // PRIOR turn's request_id back to Helix. Helix then routes
+                    // those events to the wrong interaction — fixing this
+                    // resolves both the "messages streaming in Zed don't show
+                    // up in Helix" and the "prefix mangled with another
+                    // message" symptoms.
+                    if role == "user" {
+                        let current = turn_request_id.borrow().clone();
+                        *prev_turn_request_id.borrow_mut() = current;
+                        let global_rid = crate::get_thread_request_id(&thread_id_for_sub)
+                            .unwrap_or_default();
+                        *turn_request_id.borrow_mut() = global_rid;
+                        // Reset completion tracking — the assistant-only
+                        // rotation expects current==completed to detect "I'm
+                        // done with this turn, move on", which is true at the
+                        // start of a fresh turn.
+                        *last_completed_request_id.borrow_mut() = String::new();
+                    }
                     // Update turn_request_id from the global map only at turn
                     // boundaries — i.e. when the current turn_request_id has
                     // already been used for a message_completed (matches


### PR DESCRIPTION
## Summary

Fixes a stale `request_id` bug in the WebSocket sync between Zed and Helix. The `NewEntry` handler in `crates/external_websocket_sync/src/thread_service.rs` previously rotated `turn_request_id` from the global `THREAD_REQUEST_MAP` only when `role == "assistant"` AND the previous turn had completed cleanly (`current == completed`). When the prior turn was interrupted/cancelled, or a follow-up user prompt arrived mid-stream, `last_completed_request_id` never caught up, the rotation never fired, and every subsequent assistant entry — including the re-emit loop further down — was tagged with the stale prior-turn `request_id`.

A new `UserMessage` `NewEntry` is the unambiguous start of a new turn. Force-rotate `turn_request_id` from the global map at that point regardless of completion state, and reset `last_completed_request_id` so the existing assistant-only rotation still works for subsequent turns.

## Symptoms this fixes (observed live)

- Helix sent a chat_message with `request_id=int_01kq4y8j…` (a fresh interaction created at 13:04:35).
- Zed responded with `message_added` events carrying `request_id=int_01kq4xc1…` from a turn at 12:48 — 16 minutes and several turns earlier.
- Helix's "most recent waiting interaction" fallback rescued routing on quiet sessions, but with concurrent waiting interactions it would silently land streaming tokens in the wrong interaction.
- User-visible: "messages streaming in Zed don't show up in Helix" + the prior turn's prefix mangled into the new response (because the re-emit loop ran with the stale rid, mixing old entries into the new turn's accumulator on the Helix side).

## Companion PR

Helix-side: bumps `ZED_COMMIT` to this PR's merged commit and ships the queue-UI and Vertex-thinking fixes that came out of the same investigation. https://github.com/helixml/helix/pull/2297 (will be opened right after this one).

## Test plan

- [ ] CI: zed-e2e-test passes for both `zed-agent` and `claude` rounds in `.drone.yml`'s sandbox-build pipeline (the test exercises follow-up + interrupt scenarios where this bug bites).
- [ ] Live: in the Helix UI, run a long-streaming prompt, send a follow-up via the queue mid-stream, verify the second turn's tokens land in the second interaction (not mixed into the first).
- [ ] No more stale `🗺️ [HELIX] Populated requestToInteractionMapping from streaming context (Zed-initiated message)` log lines in the Helix API where the `request_id` is many turns older than the `interaction_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)