### PR TITLE
fix: re-route AgentConnectionStore through AgentConnectionCache (redux)

### DIFF
--- a/crates/agent_ui/src/agent_connection_store.rs
+++ b/crates/agent_ui/src/agent_connection_store.rs
@@ -254,18 +254,32 @@ impl AgentConnectionStore {
         Receiver<Option<String>>,
         Task<Result<AgentConnectedState, LoadError>>,
     ) {
+        // Note: the watch channel is per-call but only the *first* caller's
+        // delegate is actually wired into `server.connect()` by the cache.
+        // Subsequent callers get the cached connection and never receive
+        // version notifications via this channel. Best-effort UI signal.
         let (new_version_tx, new_version_rx) = watch::channel::<Option<String>>(None);
 
         let agent_server_store = self.project.read(cx).agent_server_store().clone();
         let delegate = AgentServerDelegate::new(agent_server_store, Some(new_version_tx));
 
-        let connect_task = server.connect(delegate, self.project.clone(), cx);
-        let connect_task = cx.spawn(async move |_this, _cx| match connect_task.await {
+        // Route through the process-global cache so UI-driven connects share
+        // a single AgentConnection with external_websocket_sync's thread_service
+        // for the same (project, agent_id). Prevents duplicate `claude-agent-acp`
+        // wrapper spawns when the agent panel restoration races with an inbound
+        // open_thread WebSocket message (the production bug; both call sites
+        // independently call `server.connect()` without the cache).
+        let agent_id = server.agent_id();
+        let shared = agent_servers::AgentConnectionCache::request_connection(
+            cx,
+            self.project.clone(),
+            agent_id,
+            server,
+            delegate,
+        );
+        let connect_task = cx.spawn(async move |_this, _cx| match shared.await {
             Ok(connection) => Ok(AgentConnectedState { connection }),
-            Err(err) => match err.downcast::<LoadError>() {
-                Ok(load_error) => Err(load_error),
-                Err(err) => Err(LoadError::Other(SharedString::from(err.to_string()))),
-            },
+            Err(load_error) => Err(load_error),
         });
         (new_version_rx, connect_task)
     }


### PR DESCRIPTION
## Summary

Re-applies the `AgentConnectionStore` portion of [ba7e97aea6](https://github.com/helixml/zed/commit/ba7e97aea6) that was reverted in [350de991de](https://github.com/helixml/zed/commit/350de991de). The revert commit explicitly flagged this as a known-unfixed race that "can be addressed separately if it ever surfaces" — it surfaced.

## Problem

Two `claude-agent-acp` wrappers spawn for the same resumed spec-task session, each with their own `claude --resume` and their own `chrome-devtools-mcp`. One of the `chrome-devtools-mcp` instances loses the npx race and never registers, so the model talking to that wrapper sees `Error: No such tool available: mcp__chrome-devtools__*`.

Reproduced on `ubuntu-external-01kq54vkjmb...`:
- `pstree`: two `sh -c "claude-agent-acp"` parents, only one with `chrome-devtools-mcp` under it
- `Zed.log.old` at 16:02:47: **two** `[ACP_SPAWN] About to spawn ACP wrapper agent_id=AgentId("claude-acp")` lines, but only **one** `[ACP_DEDUP] No cached connection` line — confirming the second spawn skipped the cache

The race: agent panel restoration on a resumed session calls `AgentConnectionStore::request_connection` for `claude-acp` at the same instant `external_websocket_sync::thread_service::open_existing_thread_sync` does. Both paths independently call `server.connect()`. The earlier fix only routed `thread_service` through the cache, leaving the cross-path race open.

## Fix

Route `AgentConnectionStore::start_connection` through `AgentConnectionCache::request_connection` so UI-driven connects share a single `AgentConnection` with `external_websocket_sync::thread_service` for the same `(project, agent_id)`.

## Why the original revert reason no longer applies

The revert ([350de991de](https://github.com/helixml/zed/commit/350de991de)) said `E2E_AGENTS="zed-agent,claude" ./run_docker_e2e.sh` round 2 (claude) phase 1 timed out with 0 events. With current main (post the stale-flag and other `thread_service` fixes from #44 and #45 on this fork), that E2E now **passes both rounds** with this change re-applied.

```
##################################################
  FINAL RESULTS
##################################################
  [zed-agent] PASSED
  [claude] PASSED
  [store] PASSED
```

## Test plan

- [ ] `E2E_AGENTS="zed-agent,claude" ./run_docker_e2e.sh` passes (verified locally)
- [ ] In a fresh spec task: `pstree` shows only one `claude-agent-acp` parent per session
- [ ] `Zed.log` shows `[ACP_DEDUP] Reusing connection` for the second caller
- [ ] `mcp__chrome-devtools__*` tools work consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)