### PR TITLE
fix: bump context-server request timeout from 60s to 180s

### DIFF
--- a/crates/context_server/src/client.rs
+++ b/crates/context_server/src/client.rs
@@ -26,7 +26,16 @@ use crate::{
 };
 
 const JSON_RPC_VERSION: &str = "2.0";
-const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+// Helix fork: bumped from upstream's 60s. Context-server cold-start in our
+// spec-task containers can exceed 60s when several stdio MCPs spawn at the
+// same time as Zed startup — `npx <pkg>@latest` does an npm download on first
+// run, the local API container is still warming up, and CPU is contended by
+// language servers / settings-sync-daemon all booting concurrently. When the
+// initial `initialize` request times out the context_server is marked failed
+// and its tools never appear (e.g. `mcp__chrome-devtools__*` go missing).
+// 180s gives enough headroom for cold-start without making genuine failures
+// noticeably slower to surface.
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(180);
 
 // Standard JSON-RPC error codes
 pub const PARSE_ERROR: i32 = -32700;

--- a/portingguide.md
+++ b/portingguide.md
@@ -192,6 +192,9 @@ These files contain Helix-specific changes that must be preserved during rebases
 - **`show_onboarding`**: Setting to control onboarding visibility
 - **`auto_open_panel`**: Setting to control agent panel auto-open
 
+### `crates/context_server/src/client.rs`
+- **`DEFAULT_REQUEST_TIMEOUT`**: Bumped from upstream's 60s to 180s for spec-task cold-start (see Critical Fix #10)
+
 ### `.dockerignore`
 - Simplified for Helix build context
 
@@ -350,6 +353,26 @@ if !stopped_emitted_for_task.load(std::sync::atomic::Ordering::Acquire) {
 **History:** Detected via container logs showing 3 Stopped events for a single interaction, causing systematic n-1 response shift in a localhost session.
 
 **Symptom:** After an interrupt, all subsequent messages return the response for the _previous_ message. The session appears permanently "off by one."
+
+### 10. Bump Context-Server Request Timeout to 180s
+
+**File:** `crates/context_server/src/client.rs` — `DEFAULT_REQUEST_TIMEOUT` constant
+
+**Bug:** Upstream's 60s timeout on the JSON-RPC `initialize` request to a context_server is too short for our spec-task container cold-start scenario. When Zed boots, several stdio MCPs (`chrome-devtools`, `github`) spawn concurrently via `npx <pkg>@latest`, which triggers an npm download on first run. At the same time the local Helix API container (serving HTTP MCPs like `helixos`) is still warming up and the host is CPU-contended by Zed itself, settings-sync-daemon, language servers, etc. All three context_servers routinely exceed 60s and fire `Context server request timeout` simultaneously. The store marks them failed and their tools never appear — most visibly, `mcp__chrome-devtools__*` is missing for the entire session, so the model reports `Error: No such tool available: mcp__chrome-devtools__navigate_page`. Toggling the server off/on in settings appears to fix it because by then npm has cached the package, but that's a manual workaround the user shouldn't need.
+
+**Fix:** Bump the constant to 180s:
+
+```rust
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(180);
+```
+
+**Why 180s:** Cold-start `npx chrome-devtools-mcp@latest` is typically 60–90s on a contended container. 180s gives ~2x headroom without making genuine failures noticeably slower to surface in the UI.
+
+**Why not per-server `request_timeout` in settings:** Upstream's `ContextServerSettings` has no `request_timeout` field — this would be a much larger change touching settings schema, project store, and `ContextServer::new_with_timeout`. The constant bump is one line.
+
+**Symptom:** After starting a fresh spec-task, model reports `<tool_use_error>Error: No such tool available: mcp__chrome-devtools__*</tool_use_error>` for any chrome-devtools call. `Zed.log` shows three `cancelled csp request task for "initialize" id 0 which took over 60s` errors all firing at the same instant, exactly 60s after Zed startup.
+
+**History:** Triggered after the AgentConnection dedup fix landed (PR #46). Once the duplicate-spawn race was fixed and only one ACP wrapper started per session, the surviving wrapper's MCP set still depended on which context_servers had completed their `initialize` handshake before the timeout. Cold-start container = all of them failed.
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary

Bumps `DEFAULT_REQUEST_TIMEOUT` in `crates/context_server/src/client.rs` from 60s to 180s. Documents the change in `portingguide.md` (new Critical Fix #10, plus an entry under Modified Upstream Files).

## Problem

In a cold-start spec-task container, three `Context server request timeout` errors fire at the same instant — exactly 60s after Zed startup. All three context_servers are marked failed and their tools never appear for the session. Model reports:

```
<tool_use_error>Error: No such tool available: mcp__chrome-devtools__navigate_page</tool_use_error>
```

Why all three trip together:
- `chrome-devtools` and `github` are `npx <pkg>@latest` — first run does an npm download
- `helixos` is HTTP, but the local Helix API container is still warming up
- All three `initialize` requests fire in parallel during Zed boot, while CPU is contended by Zed itself, settings-sync-daemon, language servers, etc.

Reproduced in `ubuntu-external-01kq5h23dvkqzqy2jmxch8hgb2`. `Zed.log` (timestamps trimmed):

```
20:09:59  zed starting
20:10:59  ERROR cancelled csp request task for "initialize" id 0 which took over 60s
20:10:59  ERROR chrome-devtools context server failed to start: Context server request timeout
20:10:59  ERROR github context server failed to start: Context server request timeout
20:10:59  ERROR helixos context server failed to start: Context server request timeout
```

User confirmed that toggling the server off/on in Zed settings fixes it (npm has cached the package by then) — but that's a manual workaround they shouldn't need.

## Fix

```diff
-const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(180);
```

## Why 180s

Cold-start `npx chrome-devtools-mcp@latest` on a contended container is typically 60–90s. 180s gives ~2x headroom without making genuine failures noticeably slower to surface.

## Why not per-server `request_timeout` in settings

`ContextServerSettings` has no `request_timeout` field upstream. Adding one would touch the settings schema, the project store, and `ContextServer::new_with_timeout` constructor — much larger change. The constant bump is one line and benefits every MCP uniformly.

## Test plan

- [ ] Build, deploy to spec-task container, start fresh task, verify `mcp__chrome-devtools__list_pages` works on first try (no toggling)
- [ ] Verify `Zed.log` no longer shows `cancelled csp request task for "initialize"` / `Context server request timeout` errors at startup
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)