### PR TITLE
test(e2e): exclude Phase 10's own injection from Phase 16 counter

### DIFF
--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
@@ -117,9 +117,9 @@ type roundState struct {
 	// for the full diagnosis. Post-fix, no spontaneous emit should arrive
 	// because emission is deferred until the user actually sends a message
 	// in the draft. We assert spontaneousUserCreatedThreadCount == 0 at
-	// the end of each round; Phase 10 does its own user_created_thread
-	// injection via ProcessSyncEvent and is not counted here (it bypasses
-	// the WebSocket).
+	// the end of each round; Phase 10's own ProcessSyncEvent injection
+	// fires the same syncEventHook, so the user_created_thread case
+	// filters Phase 10's synthetic ID out of this counter explicitly.
 	spontaneousUserCreatedThreadCount int
 	spontaneousUserCreatedThreadIDs   []string
 }
@@ -241,6 +241,16 @@ func (d *testDriver) syncEventCallback(sessionID string, syncMsg *types.SyncMess
 		// ProcessSyncEvent injection.
 		acpThreadID, _ := syncMsg.Data["acp_thread_id"].(string)
 		if acpThreadID != "" {
+			// Phase 10's own injection goes through ProcessSyncEvent, which
+			// fires the same syncEventHook as real WebSocket-delivered events
+			// — so we have to filter it out by ID here. The synthetic format
+			// (`user-thread-{agent}-{nanos}`, see runPhase10) is generated
+			// only by the test driver, never by Zed (which uses ACP UUIDs),
+			// so this exclusion cannot mask a real Zed regression.
+			if acpThreadID == d.round.phase10NewThreadID {
+				log.Printf("[%s] Phase 10 injected user_created_thread: %s (excluded from Phase 16 counter)", d.round.agentName, truncate(acpThreadID, 16))
+				break
+			}
 			log.Printf("[%s] Spontaneous user_created_thread: %s (not tracked for phases)", d.round.agentName, truncate(acpThreadID, 16))
 			// Phase 16: count these for the deferred-emit regression
 			// assertion. Post-Fix-1a there should be zero of these per


### PR DESCRIPTION
## Summary

- Phase 16 deferred-emit assertion is failing on every Helix `main` build (e.g. https://drone.lukemarsden.net/helixml/helix/1424) because Phase 10's own injected `user_created_thread` is being miscounted as a "spontaneous" event.
- The underlying Zed deferred-emit fix from https://github.com/helixml/zed/pull/56 is in place and working — this is purely test-side bookkeeping.
- Companion bump in Helix: https://github.com/helixml/helix/pull/2427

## Root cause

Phase 10 injects a synthetic `user_created_thread` via `srv.ProcessSyncEvent(...)`. That call goes through the same `processExternalAgentSyncMessage` path as real WebSocket-delivered events, so it fires `syncEventCallback` → `spontaneousUserCreatedThreadCount++`. The Phase 16 assertion then fails with:

> Phase 16 (deferred-emit regression): received 1 spontaneous user_created_thread event(s) … Phantom acp_thread_id(s): [user-thread-zed-agent-1778708669163834033]

Both rounds (`zed-agent` and `claude`) fail with exactly 1 phantom event whose `acp_thread_id` matches the synthetic format `user-thread-{agent}-{nanos}` generated only by `runPhase10`. The pinned `ZED_COMMIT` in Helix already includes PR #56, so Zed itself isn't regressing.

## Fix

Filter out Phase 10's known synthetic `acp_thread_id` from the Phase 16 counter by exact match. Zed only ever emits ACP UUIDs, never `user-thread-*`, so the exclusion cannot mask a real regression — any other `user_created_thread` event still fails Phase 16 as before.

Updated the doc comment on `spontaneousUserCreatedThreadCount` to be accurate about why the exclusion is necessary (the original comment incorrectly assumed `ProcessSyncEvent` "bypasses" the WebSocket path that fires the hook).

## Test plan

- [x] Verified locally: `cd crates/external_websocket_sync/e2e-test && E2E_AGENTS="zed-agent,claude" ./run_docker_e2e.sh` — both rounds PASSED, Phase 16 reports `0 spontaneous user_created_thread events — Fix 1a deferred-emit working as expected`. Exclusion log line fires exactly once per round (matches the one Phase 10 injection per round).

🤖 Generated with [Claude Code](https://claude.com/claude-code)