### PR TITLE
fix(external-agent): emit agent_ready when reopening an already-loaded thread

### DIFF
--- a/crates/external_websocket_sync/Cargo.toml
+++ b/crates/external_websocket_sync/Cargo.toml
@@ -63,6 +63,7 @@ uuid.workspace = true
 watch.workspace = true
 
 [dev-dependencies]
+acp_thread = { workspace = true, features = ["test-support"] }
 env_logger.workspace = true
 fs.workspace = true
 gpui = { workspace = true, features = ["test-support"] }

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -2260,6 +2260,20 @@ fn open_existing_thread_sync(
         if let Some(thread_entity) = thread_weak.upgrade() {
             ensure_thread_subscription(&thread_entity, &request.acp_thread_id, cx);
         }
+        // Emit agent_ready, exactly like the other three load paths (fresh load,
+        // slow-path sync load, lock-wait recheck). On reconnect the external
+        // client sends open_thread, which suppresses the connection loop's 5s
+        // fallback agent_ready and delegates the ready signal to the thread
+        // service. Without this, a thread that is still in the registry never
+        // gets an agent_ready and the client's readiness wait times out on every
+        // reconnect.
+        let agent_name_for_ready = request
+            .agent_name
+            .clone()
+            .unwrap_or_else(|| "zed-agent".to_string());
+        // Persist the agent backing this thread (see set_thread_agent_name doc).
+        set_thread_agent_name(&request.acp_thread_id, agent_name_for_ready.clone());
+        crate::send_agent_ready(agent_name_for_ready, Some(request.acp_thread_id.clone()));
         // TODO: Still need to notify AgentPanel to display it
         return Ok(());
     }

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -2693,3 +2693,127 @@ mod pending_user_created_emit_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod agent_ready_on_reconnect_tests {
+    //! Regression test for the agent-readiness handshake on reconnect.
+    //!
+    //! When the external sync client reconnects it sends `open_thread`, which
+    //! suppresses the connection loop's 5s fallback `agent_ready`
+    //! (see `websocket_sync.rs`) and delegates emitting the ready signal to the
+    //! thread service. `open_existing_thread_sync` has four load paths: the fresh
+    //! load, the slow-path sync load, and the lock-wait recheck all emit
+    //! `agent_ready` after loading — but the "already loaded in registry"
+    //! fast-path returns `Ok(())` WITHOUT emitting it. So when a thread is still in
+    //! the in-process registry on reconnect, `agent_ready` is never sent and the
+    //! client's readiness wait times out.
+    //!
+    //! This test pins the fast-path to the same contract as the other three paths.
+    //! It is RED until the registry fast-path emits `agent_ready` before returning.
+
+    use super::*;
+    use crate::types::SyncEvent;
+    use crate::websocket_sync::{WebSocketSync, WEBSOCKET_SERVICE};
+    use acp_thread::{AgentConnection, StubAgentConnection};
+    use fs::FakeFs;
+    use gpui::{AppContext as _, TestAppContext};
+    use project::Project;
+    use settings::SettingsStore;
+    use std::rc::Rc;
+    use util::path_list::PathList;
+
+    fn init_test(cx: &mut TestAppContext) {
+        env_logger::try_init().ok();
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+        });
+    }
+
+    #[gpui::test]
+    async fn open_thread_on_already_registered_thread_emits_agent_ready(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        // Build a real AcpThread entity via the stub connection and register it —
+        // simulating a thread entity that survived in the in-process registry
+        // across a WebSocket reconnect (the precise fast-path trigger).
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let connection = Rc::new(StubAgentConnection::new());
+        let thread = cx
+            .update(|cx| {
+                connection
+                    .clone()
+                    .new_session(project.clone(), PathList::default(), cx)
+            })
+            .await
+            .expect("stub new_session should succeed");
+
+        // The external thread id (the registry key) is distinct from the ACP
+        // session id. Unique per run so the process-global registry / subscription
+        // statics don't collide with other tests.
+        let acp_thread_id = format!(
+            "test-reconnect-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        register_thread(acp_thread_id.clone(), thread);
+        assert!(
+            get_thread(&acp_thread_id).is_some(),
+            "precondition: thread must be in the registry so open_existing_thread_sync \
+             takes the 'already loaded' fast-path"
+        );
+
+        // Install a recording WebSocket service so send_agent_ready is observable
+        // (without it, send_websocket_event errors on an uninitialised service).
+        let (service, mut events_rx) = WebSocketSync::new_test();
+        *WEBSOCKET_SERVICE.lock() = Some(service);
+
+        // Exercise the reconnect `open_thread` against the already-registered thread.
+        let request = ThreadOpenRequest {
+            acp_thread_id: acp_thread_id.clone(),
+            agent_name: Some("zed-agent".to_string()),
+        };
+        let history_store = cx.update(|cx| cx.new(|cx| ThreadStore::new(cx)));
+        let unused_fs: Arc<dyn Fs> = FakeFs::new(cx.executor());
+        cx.update(|cx| {
+            open_existing_thread_sync(project.clone(), history_store, unused_fs, request, cx)
+                .expect("open_existing_thread_sync should return Ok on the fast-path");
+        });
+        cx.run_until_parked();
+
+        // Drain emitted events and count AgentReady for this thread.
+        let mut agent_ready_count = 0;
+        while let Ok(event) = events_rx.try_recv() {
+            if let SyncEvent::AgentReady { thread_id, .. } = event {
+                if thread_id.as_deref() == Some(acp_thread_id.as_str()) {
+                    agent_ready_count += 1;
+                }
+            }
+        }
+
+        // Tear down all process-global state this test touched, BEFORE the
+        // assertion, so it runs on both the pass and fail paths:
+        //  - the recording WebSocket service (else it leaks into other tests);
+        //  - the registry + keep-alive strong refs to the AcpThread entity (else
+        //    the gpui test harness panics with "leaked handle" at App teardown,
+        //    since THREAD_KEEP_ALIVE intentionally holds a permanent strong ref).
+        *WEBSOCKET_SERVICE.lock() = None;
+        unregister_thread(&acp_thread_id);
+        if let Some(keep_alive) = THREAD_KEEP_ALIVE.lock().as_ref() {
+            keep_alive.write().remove(&acp_thread_id);
+        }
+        cx.run_until_parked();
+
+        assert_eq!(
+            agent_ready_count, 1,
+            "open_thread on an already-registered thread MUST emit exactly one \
+             agent_ready, like the other three load paths in \
+             open_existing_thread_sync. The registry fast-path currently omits it; \
+             because the 5s fallback agent_ready was suppressed when open_thread \
+             arrived, the readiness wait then times out."
+        );
+    }
+}

--- a/crates/external_websocket_sync/src/websocket_sync.rs
+++ b/crates/external_websocket_sync/src/websocket_sync.rs
@@ -575,6 +575,21 @@ impl WebSocketSync {
     pub fn get_reconnect_delay_ms(&self) -> u64 {
         self.reconnect_delay_ms.load(Ordering::SeqCst)
     }
+
+    /// Test-only: build a service whose outgoing events can be observed via the
+    /// returned receiver, without opening a real WebSocket connection. Install it
+    /// into `WEBSOCKET_SERVICE` so `send_websocket_event` / `send_agent_ready`
+    /// deliver into the receiver instead of erroring on an uninitialised service.
+    #[cfg(test)]
+    pub(crate) fn new_test() -> (Arc<Self>, mpsc::UnboundedReceiver<SyncEvent>) {
+        let (outgoing_tx, outgoing_rx) = mpsc::unbounded_channel::<SyncEvent>();
+        let service = Arc::new(Self {
+            outgoing_tx,
+            is_connected: Arc::new(AtomicBool::new(true)),
+            reconnect_delay_ms: Arc::new(AtomicU64::new(INITIAL_RECONNECT_DELAY_MS)),
+        });
+        (service, outgoing_rx)
+    }
 }
 
 /// Global WebSocket service instance


### PR DESCRIPTION
## Summary

Fixes a reconnect bug in `external_websocket_sync` that made long-lived agent
sessions stall and degrade: when reopening a thread that was still loaded in the
in-process registry, Zed never sent `agent_ready`, so the controlling client's
readiness wait timed out on every reconnect. This PR makes the registry
fast-path emit `agent_ready` like the other three load paths, with a red→green
test that pins the contract.

## The problem, in plain terms

When you chat with an agent session, it runs inside a long-lived editor process
(Zed). Zed and the controlling client talk over a WebSocket that drops and
reconnects fairly often (network blips, idle wake-ups, prior timeouts). On every
reconnect, the client asks Zed to re-open the conversation and then waits for Zed
to signal "I'm ready" before sending the next message.

The bug: when the conversation is one Zed already has open in memory — which is
always the case for a session that has been alive a while — Zed silently skipped
the "I'm ready" signal. The client had also already disabled its own backup
signal the moment it asked to re-open the thread, so nothing told it the agent
was ready. It waited, then gave up after **60 seconds** and sent the message
anyway. That 60-second stall happened on *every* reconnect, and the late,
out-of-order delivery then corrupted the conversation — replies got dropped or
came back empty, which made the session error more, reconnect more, and stall
again. A slow downward spiral.

Short-lived sessions never hit this: they don't live long enough to reconnect to
a conversation that's already open in memory. Long-lived sessions hit it
constantly — which is exactly why they were the flaky ones.

## The fix

`open_existing_thread_sync`
(`crates/external_websocket_sync/src/thread_service.rs`) has four load paths.
Three — fresh load, slow-path sync load, lock-wait recheck — emit `agent_ready`
after loading; the **"already loaded in registry" fast-path** returned `Ok(())`
without it. The fix makes the fast-path do what the other three do: persist the
agent name via `set_thread_agent_name`, then `send_agent_ready`, before
returning.

## The test (red → green)

`#[gpui::test] open_thread_on_already_registered_thread_emits_agent_ready`:

1. builds a real `AcpThread` via `StubAgentConnection::new_session` and
   `register_thread`s it, so `open_existing_thread_sync` hits the registry
   fast-path (precondition asserted);
2. installs a recording `WEBSOCKET_SERVICE` via a new `#[cfg(test)]`
   `WebSocketSync::new_test() -> (Arc<Self>, UnboundedReceiver<SyncEvent>)` seam
   so `send_agent_ready` is observable (it otherwise errors on an uninitialised
   service);
3. drives the reconnect `open_thread` and asserts **exactly one** `AgentReady`
   fires for that thread;
4. tears down the recording service + registry/keep-alive strong refs before the
   assertion so the gpui harness doesn't flag a leaked entity handle
   (`THREAD_KEEP_ALIVE` holds a permanent strong ref by design).

The PR is split into two commits — the **pre-fix red test** (verified RED:
`agent_ready_count == 0`), then the **fix that turns it green** — so the
regression is demonstrably covered.

## Verification

| State | Result |
|---|---|
| Red-test commit alone | **RED** — `agent_ready_count == 0` (`left: 0, right: 1`) |
| With the fix (this PR's tip) | **GREEN** |
| Full crate (`cargo test -p external_websocket_sync --lib`) | **44 passed, 4 ignored** |

```
cargo test -p external_websocket_sync --lib agent_ready_on_reconnect
```

## Manual end-to-end verification (rebuilt desktop image)

Built this branch into the desktop image and exercised the real reconnect path
against a live session (binary checksum-verified to match the build):

1. Started a fresh desktop session — initial boot took the **slow path** and sent
   `agent_ready`, registering the thread in the long-running Zed process.
2. Forced a WebSocket reconnect (bounced the controlling server) while the Zed
   process — and its in-process thread registry — stayed alive.
3. On reconnect the server re-sent `open_thread`, and Zed hit the
   **"Thread already loaded in registry" fast-path** — the exact branch this PR
   fixes.

Observed on the same log line that used to go silent:

```
✅ [THREAD_SERVICE] Thread already loaded in registry: <thread-id>
🚀 [WEBSOCKET] Sending agent_ready event: agent_name=…, thread_id=Some("<thread-id>")
✅ [WEBSOCKET] agent_ready event sent successfully
```

The server logged **zero** `Timeout waiting for agent_ready` events past the 60s
readiness deadline — i.e. the reconnect completed the readiness handshake
instantly instead of stalling. That is the pre-fix fingerprint, inverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
