### PR TITLE
fix(external_websocket_sync): emit terminal frame when ACP agent crashes mid-turn

### DIFF
--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -911,6 +911,20 @@ mod test_support {
                 .send(stop_reason)
                 .unwrap();
         }
+
+        /// Simulate the agent process exiting mid-turn: drop the pending turn's
+        /// response sender without sending a `StopReason`, so the `prompt`
+        /// future's `rx.await?` resolves to `Err` — the same path run_turn takes
+        /// on a real ACP agent crash (emits `AcpThreadEvent::Error`, not `Stopped`).
+        pub fn fail_turn(&self, session_id: acp::SessionId) {
+            self.sessions
+                .lock()
+                .get_mut(&session_id)
+                .unwrap()
+                .response_tx
+                .take()
+                .expect("No pending turn");
+        }
     }
 
     impl AgentConnection for StubAgentConnection {

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -739,10 +739,12 @@ pub fn get_thread(acp_thread_id: &str) -> Option<WeakEntity<AcpThread>> {
 /// that create or load threads must call this to set up the subscription. It is
 /// idempotent — if a persistent subscription already exists, it does nothing.
 ///
-/// Handles three events:
+/// Handles four events:
 /// - `NewEntry`: new user/assistant message → send `message_added`
 /// - `EntryUpdated`: streaming tokens / tool call updates → throttled `message_added`
 /// - `Stopped`: turn completed → flush throttle + send `message_completed`
+/// - `Error`: turn aborted (agent process exited mid-turn, or MaxTokens) →
+///   flush + send `chat_response_error` so Helix errors the interaction
 pub fn ensure_thread_subscription(
     thread_entity: &Entity<AcpThread>,
     thread_id: &str,
@@ -978,10 +980,16 @@ pub fn ensure_thread_subscription(
                     );
                 }
             }
-            AcpThreadEvent::Stopped(_) => {
+            // Stopped and Error are both turn-terminal and must send Helix a
+            // terminal frame to free the activation lane. Stopped → completed;
+            // Error (agent process exited mid-turn, or MaxTokens — run_turn's Err
+            // arm) → chat_response_error. Without the Error arm a crashed agent
+            // that streamed partial output wedges the worker forever.
+            AcpThreadEvent::Stopped(_) | AcpThreadEvent::Error => {
+                let is_error = matches!(event, AcpThreadEvent::Error);
                 flush_streaming_throttle(&thread_id_for_sub);
 
-                // AcpThread calls flush_streaming_text before emitting Stopped, so all
+                // AcpThread calls flush_streaming_text before emitting Stopped/Error, so all
                 // Markdown entities now have their complete buffered text. Send corrected
                 // content for ALL entries — EntryUpdated events during streaming carried
                 // incomplete content (text was still in the streaming buffer at that point),
@@ -1062,15 +1070,56 @@ pub fn ensure_thread_subscription(
                     captured_rid
                 };
                 *last_completed_request_id.borrow_mut() = completed_rid.clone();
-                eprintln!(
-                    "📤 [THREAD_SERVICE] Stopped event: sending message_completed for thread {} (request_id={})",
-                    thread_id_for_sub, completed_rid
-                );
-                let _ = crate::send_websocket_event(SyncEvent::MessageCompleted {
-                    acp_thread_id: thread_id_for_sub.clone(),
-                    message_id: "0".to_string(),
-                    request_id: completed_rid,
-                });
+                if is_error {
+                    // Turn aborted (agent process exited mid-turn, or MaxTokens).
+                    // Emit chat_response_error, NOT message_completed: Helix's
+                    // handleChatResponseError marks the interaction state=error
+                    // (vs masking a crash as a normal completion) and ends the
+                    // activation, freeing the per-Worker lane.
+                    //
+                    // AcpThreadEvent::Error carries no cause string, so the
+                    // payload is generic — the real exit reason (e.g. "process
+                    // exited with code 143") is logged by acp_thread::run_turn
+                    // just before this fires: grep Zed.log for "Error in run
+                    // turn" near this request_id. We also log the
+                    // streamed-then-died signal (partial entry count + bytes) so
+                    // a future wedge is identifiable from Zed.log alone, without
+                    // reconstructing it from Helix DB state.
+                    let turn_entries = entries.len().saturating_sub(turn_start);
+                    let partial_bytes: usize = entries
+                        .iter()
+                        .skip(turn_start)
+                        .map(|e| match e {
+                            acp_thread::AgentThreadEntry::AssistantMessage(m) => {
+                                m.content_only(cx).len()
+                            }
+                            acp_thread::AgentThreadEntry::ToolCall(tc) => tc.to_markdown(cx).len(),
+                            _ => 0,
+                        })
+                        .sum();
+                    log::warn!(
+                        "🛑 [THREAD_SERVICE] turn ABORTED (AcpThreadEvent::Error) thread={} request_id={} \
+                         streamed {} partial entries / {} bytes before dying — emitting chat_response_error \
+                         to mark the interaction errored and free the Helix activation lane",
+                        thread_id_for_sub, completed_rid, turn_entries, partial_bytes
+                    );
+                    let _ = crate::send_websocket_event(SyncEvent::ChatResponseError {
+                        request_id: completed_rid,
+                        error: "agent turn aborted: the ACP agent process exited mid-turn or hit \
+                                max tokens (see Zed.log 'Error in run turn' for the cause)"
+                            .to_string(),
+                    });
+                } else {
+                    eprintln!(
+                        "📤 [THREAD_SERVICE] Stopped event: sending message_completed for thread {} (request_id={})",
+                        thread_id_for_sub, completed_rid
+                    );
+                    let _ = crate::send_websocket_event(SyncEvent::MessageCompleted {
+                        acp_thread_id: thread_id_for_sub.clone(),
+                        message_id: "0".to_string(),
+                        request_id: completed_rid,
+                    });
+                }
             }
             _ => {}
         }
@@ -2558,6 +2607,12 @@ fn open_existing_thread_sync(
     Ok(())
 }
 
+/// Serializes tests that install a recording WebSocket service into the
+/// process-global `WEBSOCKET_SERVICE`. Without it, two such tests running on
+/// parallel cargo threads stomp each other's service and lose events.
+#[cfg(test)]
+static TEST_WEBSOCKET_SERVICE_GUARD: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
 #[cfg(test)]
 mod pending_user_created_emit_tests {
     //! Regression tests for the deferred-emission machinery that backs Fix 1a
@@ -2746,6 +2801,7 @@ mod agent_ready_on_reconnect_tests {
 
     #[gpui::test]
     async fn open_thread_on_already_registered_thread_emits_agent_ready(cx: &mut TestAppContext) {
+        let _ws_guard = super::TEST_WEBSOCKET_SERVICE_GUARD.lock();
         init_test(cx);
 
         // Build a real AcpThread entity via the stub connection and register it —
@@ -2828,6 +2884,120 @@ mod agent_ready_on_reconnect_tests {
              open_existing_thread_sync. The registry fast-path currently omits it; \
              because the 5s fallback agent_ready was suppressed when open_thread \
              arrived, the readiness wait then times out."
+        );
+    }
+}
+
+#[cfg(test)]
+mod agent_process_crash_tests {
+    //! Regression test for the "streamed-then-died" stuck-turn wedge.
+    //!
+    //! When the ACP agent process exits mid-turn, run_turn emits
+    //! `AcpThreadEvent::Error` (not `Stopped`). The subscription must emit a
+    //! terminal `chat_response_error` for the in-flight `request_id` so Helix's
+    //! handleChatResponseError marks the interaction errored and frees the
+    //! activation lane — otherwise the worker wedges forever.
+
+    use super::*;
+    use crate::types::SyncEvent;
+    use crate::websocket_sync::{WebSocketSync, WEBSOCKET_SERVICE};
+    use acp_thread::{AcpThread, AgentConnection, StubAgentConnection};
+    use fs::FakeFs;
+    use gpui::{AppContext as _, TestAppContext};
+    use project::Project;
+    use settings::SettingsStore;
+    use std::rc::Rc;
+    use util::path_list::PathList;
+
+    fn init_test(cx: &mut TestAppContext) {
+        env_logger::try_init().ok();
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+        });
+    }
+
+    #[gpui::test]
+    async fn agent_process_crash_mid_turn_emits_terminal_frame(cx: &mut TestAppContext) {
+        let _ws_guard = TEST_WEBSOCKET_SERVICE_GUARD.lock();
+        init_test(cx);
+
+        // Stub leaves the turn pending so we can crash it mid-flight below.
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let connection = Rc::new(StubAgentConnection::new());
+        let thread: Entity<AcpThread> = cx
+            .update(|cx| {
+                connection
+                    .clone()
+                    .new_session(project.clone(), PathList::default(), cx)
+            })
+            .await
+            .expect("stub new_session should succeed");
+
+        let session_id = cx.read(|cx| thread.read(cx).session_id().clone());
+
+        // Unique ids so the process-global statics don't collide across tests.
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let acp_thread_id = format!("test-crash-{}", nonce);
+        let request_id = format!("req-crash-{}", nonce);
+
+        // request_id must be set before the subscription so the turn captures it.
+        set_thread_request_id(acp_thread_id.clone(), request_id.clone());
+        register_thread(acp_thread_id.clone(), thread.clone());
+        cx.update(|cx| ensure_thread_subscription(&thread, &acp_thread_id, cx));
+
+        let (service, mut events_rx) = WebSocketSync::new_test();
+        *WEBSOCKET_SERVICE.lock() = Some(service);
+
+        // Drive the turn future on the foreground executor — it only resolves
+        // once the turn ends, but its run_turn machinery emits the events.
+        let send_fut = cx.update(|cx| {
+            thread.update(cx, |thread, cx| {
+                thread.send(vec!["partial output then crash".into()], cx)
+            })
+        });
+        cx.foreground_executor()
+            .spawn(async move {
+                let _ = send_fut.await;
+            })
+            .detach();
+        cx.run_until_parked();
+
+        // Crash the agent mid-turn → run_turn emits AcpThreadEvent::Error.
+        connection.fail_turn(session_id);
+        cx.run_until_parked();
+
+        let mut terminal_for_turn = 0;
+        while let Ok(event) = events_rx.try_recv() {
+            if let SyncEvent::ChatResponseError { request_id: rid, error } = event {
+                if rid == request_id {
+                    assert!(!error.is_empty(), "chat_response_error must carry an error payload");
+                    terminal_for_turn += 1;
+                }
+            }
+        }
+
+        // Tear down process-global state before asserting (THREAD_KEEP_ALIVE
+        // holds a permanent strong ref → "leaked handle" panic otherwise).
+        *WEBSOCKET_SERVICE.lock() = None;
+        unregister_thread(&acp_thread_id);
+        if let Some(keep_alive) = THREAD_KEEP_ALIVE.lock().as_ref() {
+            keep_alive.write().remove(&acp_thread_id);
+        }
+        cx.run_until_parked();
+
+        assert_eq!(
+            terminal_for_turn, 1,
+            "when the ACP agent process exits mid-turn, AcpThread emits \
+             AcpThreadEvent::Error and the subscription MUST forward a terminal \
+             chat_response_error frame for the in-flight request_id so Helix's \
+             handleChatResponseError marks the interaction errored and frees the \
+             activation lane. Without an Error arm the crash is swallowed and the \
+             interaction stays waiting forever — the permanent worker wedge."
         );
     }
 }

--- a/crates/external_websocket_sync/src/types.rs
+++ b/crates/external_websocket_sync/src/types.rs
@@ -223,6 +223,14 @@ pub enum SyncEvent {
         request_id: String,
         error: String,
     },
+    /// Sent when a turn aborts (ACP agent process exited mid-turn, or MaxTokens).
+    /// Helix's handleChatResponseError marks the interaction state=error with
+    /// this message and ends the activation, freeing the per-Worker lane.
+    #[serde(rename = "chat_response_error")]
+    ChatResponseError {
+        request_id: String,
+        error: String,
+    },
     /// Sent when the agent (e.g., qwen-code) has finished initialization and is ready to receive prompts
     /// This prevents race conditions where Helix sends prompts before the agent is ready
     #[serde(rename = "agent_ready")]
@@ -309,6 +317,13 @@ impl SyncEvent {
                 "thread_load_error".to_string(),
                 serde_json::json!({
                     "acp_thread_id": acp_thread_id,
+                    "request_id": request_id,
+                    "error": error,
+                })
+            ),
+            SyncEvent::ChatResponseError { request_id, error } => (
+                "chat_response_error".to_string(),
+                serde_json::json!({
                     "request_id": request_id,
                     "error": error,
                 })


### PR DESCRIPTION
## Problem

An org worker (`w-docs-engineer`) was permanently wedged: no activations for hours despite new events arriving on its subscribed streams.

Root cause: when the ACP agent process (Claude Agent) exits **mid-turn**, `AcpThread::run_turn` takes its `Err` arm and emits **`AcpThreadEvent::Error`** — *not* `Stopped`. The persistent thread subscription in `ensure_thread_subscription` only sent a terminal frame to Helix from its `Stopped` handler; there was **no `Error` arm**, so the crash was swallowed (the code just logged `✅ Message send awaited - AI response complete` and moved on).

Helix only leaves `state=waiting` on a terminal event. So a turn that streamed partial output (27 KB / 24 entries in the incident) and then crashed stayed `waiting` forever, holding the per-Worker activation lane and permanently freezing the worker. Helix's stuck-turn watchdog couldn't recover it either — it filters on *empty* output (`response_message='' AND response_entries IS NULL`), and this turn had streamed content. One crash → permanent wedge.

## Fix

Add an `Error` arm (combined with `Stopped`, since both are turn-terminal) that flushes partial content and emits **`chat_response_error`** for the in-flight `request_id`.

Helix's **existing** `handleChatResponseError` handler then marks the interaction `state=error` and ends the activation, freeing the lane. No Helix-side change is needed. This is strictly better than `message_completed`, which would mask a crash as a normal completion carrying truncated output. Verified the lane-freeing chain on the Helix side:

- `getSessionOutput` → `Status = string(last.State)` → `"error"`
- `IsTerminalOutput` → `Status == "complete" || Status == "error"`
- `pollUntilDone` → terminal `error` → ends the activation

### Logging

`AcpThreadEvent::Error` carries no cause string, so the `chat_response_error` payload is generic. The real exit reason (e.g. *"process exited with code 143"* = SIGTERM) is logged by `acp_thread::run_turn` as `Error in run turn: …` immediately before this fires. A `log::warn!` here records the **streamed-then-died signal** (partial entry count + bytes) and `request_id`, so a future wedge is identifiable from `Zed.log` alone without reconstructing it from Helix DB state:

```
ERROR acp_thread] Error in run turn: <exit reason>
WARN  thread_service] 🛑 turn ABORTED (AcpThreadEvent::Error) thread=… request_id=… streamed 24 partial entries / 27038 bytes before dying — emitting chat_response_error …
```

## Changes

- `types.rs`: add `SyncEvent::ChatResponseError { request_id, error }` (serializes to `chat_response_error`).
- `thread_service.rs`: `Stopped(_) | Error` arm; `Error` → `chat_response_error` + diagnostic `log::warn!`.
- `connection.rs`: `StubAgentConnection::fail_turn` test helper (drops the pending response sender → `prompt` future errors, reproducing a real agent crash).
- Regression test `agent_process_crash_mid_turn_emits_terminal_frame`, plus a `TEST_WEBSOCKET_SERVICE_GUARD` shared with the pre-existing reconnect test (both install the process-global recording WebSocket service and would otherwise race under parallel cargo threads).

## Testing

`cargo test -p external_websocket_sync` — **45 passed** in parallel. The new test is red without the `Error` arm, green with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)