### PR TITLE
fix(agent): wait for configured native model

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -35,6 +35,7 @@ use agent_skills::{
     SkillSource, SkillSummary, builtin_skills, global_skills_dir, load_skills_from_directory,
     parse_skill_frontmatter, project_skills_relative_path, read_skill_body_from_content,
 };
+use agent_settings::AgentSettings;
 use anyhow::{Context as _, Result, anyhow};
 use chrono::{DateTime, Utc};
 use collections::{HashMap, HashSet, IndexMap};
@@ -2074,6 +2075,26 @@ impl NativeAgentConnection {
             .map(|session| session.thread.clone())
     }
 
+    pub fn new_session_with_configured_model(
+        &self,
+        project: Entity<Project>,
+        cx: &mut App,
+    ) -> Option<Entity<AcpThread>> {
+        self.0.update(cx, |agent, cx| {
+            let configured = AgentSettings::get_global(cx).default_model.as_ref()?;
+            let registry_default = LanguageModelRegistry::read_global(cx).default_model()?;
+            if configured.provider.0.as_str() != registry_default.provider.id().0.as_ref()
+                || configured.model != registry_default.model.id().0.as_ref()
+            {
+                return None;
+            }
+            agent
+                .models
+                .model_from_id(&LanguageModels::model_id(&registry_default.model))?;
+            Some(agent.new_session(project, cx))
+        })
+    }
+
     /// Forwards to [`NativeAgent::ensure_skills_scan_started`]. The
     /// agent panel calls this from its three user-interaction trigger
     /// points (input box focus, slash-autocomplete invocation, and
@@ -3714,7 +3735,7 @@ mod internal_tests {
     use acp_thread::{AgentConnection, AgentModelGroupName, AgentModelInfo, MentionUri};
     use agent_settings::COMPACTION_PROMPT;
     use fs::FakeFs;
-    use gpui::TestAppContext;
+    use gpui::{TestAppContext, UpdateGlobal as _};
     use indoc::formatdoc;
     use language_model::fake_provider::{FakeLanguageModel, FakeLanguageModelProvider};
     use language_model::{
@@ -6648,6 +6669,68 @@ mod internal_tests {
 
             LanguageModelRegistry::test(cx);
         });
+    }
+
+    #[gpui::test]
+    async fn configured_session_uses_exact_cached_model(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.agent.get_or_insert_default().default_model =
+                        Some(LanguageModelSelection {
+                            provider: "fake".into(),
+                            model: "fake".to_string(),
+                            enable_thinking: false,
+                            effort: None,
+                            speed: None,
+                        });
+                });
+            });
+        });
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/", json!({ "a": {} })).await;
+        let project = Project::test(fs.clone(), [], cx).await;
+        let thread_store = cx.new(|cx| ThreadStore::new(cx));
+        let agent = cx.update(|cx| NativeAgent::new(thread_store, Templates::new(), fs, cx));
+        let connection = NativeAgentConnection(agent.clone());
+
+        cx.update(|cx| {
+            let configured = AgentSettings::get_global(cx).default_model.as_ref().unwrap();
+            let registry_default = LanguageModelRegistry::read_global(cx).default_model().unwrap();
+            assert_eq!(configured.provider.0.as_str(), registry_default.provider.id().0.as_ref());
+            assert_eq!(configured.model, registry_default.model.id().0.as_ref());
+            let model_id = LanguageModels::model_id(&registry_default.model);
+            assert!(agent.read(cx).models.model_from_id(&model_id).is_some());
+        });
+        let settings_before =
+            cx.update(|cx| AgentSettings::get_global(cx).default_model.clone());
+        let session = cx
+            .update(|cx| {
+                connection.new_session_with_configured_model(project.clone(), cx)
+            })
+            .expect("matching settings, registry, and cache should create a session");
+        let session_id = session.read_with(cx, |thread, _cx| thread.session_id().clone());
+        agent.read_with(cx, |agent, cx| {
+            agent.sessions[&session_id]
+                .thread
+                .read_with(cx, |thread, _cx| {
+                    let model = thread.model().unwrap();
+                    assert_eq!(model.provider_id().0.as_ref(), "fake");
+                    assert_eq!(model.id().0.as_ref(), "fake");
+                });
+        });
+        let settings_after =
+            cx.update(|cx| AgentSettings::get_global(cx).default_model.clone());
+        assert_eq!(settings_after, settings_before);
+
+        let session_count = agent.read_with(cx, |agent, _cx| agent.sessions.len());
+        agent.update(cx, |agent, _cx| agent.models.models.clear());
+        let missing =
+            cx.update(|cx| connection.new_session_with_configured_model(project, cx));
+
+        assert!(missing.is_none());
+        agent.read_with(cx, |agent, _cx| assert_eq!(agent.sessions.len(), session_count));
     }
 
     #[test]

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -28,6 +28,38 @@ fn zed_agent_server_id(agent_name: &str) -> &str {
     }
 }
 
+fn report_thread_creation_failure(request_id: &str, error: &str) {
+    if let Err(send_err) = crate::send_websocket_event(SyncEvent::ChatResponseError {
+        request_id: request_id.to_string(),
+        error: error.to_string(),
+    }) {
+        log::error!("[THREAD_SERVICE] Failed to send thread creation error: {}", send_err);
+    }
+}
+
+async fn create_native_session_when_ready(
+    connection: std::rc::Rc<agent::NativeAgentConnection>,
+    project: Entity<Project>,
+    request_id: String,
+    cx: gpui::AsyncApp,
+) -> Result<Entity<AcpThread>> {
+    let executor = cx.background_executor().clone();
+    let deadline = executor.now() + Duration::from_secs(15);
+    loop {
+        if let Some(entity) = cx.update(|cx| {
+            connection.new_session_with_configured_model(project.clone(), cx)
+        }) {
+            return Ok(entity);
+        }
+        if executor.now() >= deadline {
+            let error = "configured NativeAgent model did not become available within 15s";
+            report_thread_creation_failure(&request_id, error);
+            return Err(anyhow::anyhow!(error));
+        }
+        executor.timer(Duration::from_millis(100)).await;
+    }
+}
+
 fn report_thread_open_failure(request: &ThreadOpenRequest, error: &anyhow::Error) {
     let Some(request_id) = request.request_id.clone().filter(|id| !id.is_empty()) else {
         return;
@@ -1684,6 +1716,7 @@ fn create_new_thread_sync(
             }
         }
     };
+    let is_native_agent = matches!(&agent, ExternalAgent::NativeAgent);
 
     // Spawn async task to complete the connection and create the thread
     let request_clone = request.clone();
@@ -1771,16 +1804,36 @@ fn create_new_thread_sync(
         let connection_for_model = connection.clone();
         let work_dirs = PathList::new(&[cwd.clone()]);
         eprintln!("🧵 [THREAD_SERVICE] Calling new_session() with cwd={:?}", cwd);
-        let thread_entity: Entity<AcpThread> = match cx.update(|cx| {
-            connection.new_session(project_clone.clone(), work_dirs, cx)
-        }).await {
-            Ok(entity) => {
-                eprintln!("✅ [THREAD_SERVICE] new_session() succeeded");
-                entity
-            }
-            Err(e) => {
-                eprintln!("❌ [THREAD_SERVICE] new_session() failed: {}", e);
-                return Err(e);
+        let thread_entity: Entity<AcpThread> = if is_native_agent {
+            let Some(native_connection) = connection
+                .clone()
+                .downcast::<agent::NativeAgentConnection>()
+            else {
+                let error = "NativeAgent connection had unexpected type";
+                report_thread_creation_failure(&request_clone.request_id, error);
+                return Err(anyhow::anyhow!(error));
+            };
+            let entity = create_native_session_when_ready(
+                native_connection,
+                project_clone.clone(),
+                request_clone.request_id.clone(),
+                cx.clone(),
+            )
+            .await?;
+            eprintln!("✅ [THREAD_SERVICE] new_session() succeeded");
+            entity
+        } else {
+            match cx.update(|cx| {
+                connection.new_session(project_clone.clone(), work_dirs, cx)
+            }).await {
+                Ok(entity) => {
+                    eprintln!("✅ [THREAD_SERVICE] new_session() succeeded");
+                    entity
+                }
+                Err(e) => {
+                    eprintln!("❌ [THREAD_SERVICE] new_session() failed: {}", e);
+                    return Err(e);
+                }
             }
         };
 
@@ -2637,6 +2690,7 @@ mod thread_open_failure_tests {
     use gpui::{AppContext as _, TestAppContext};
     use project::Project;
     use settings::SettingsStore;
+    use std::rc::Rc;
 
     #[test]
     fn thread_open_failure_preserves_request_correlation() {
@@ -2665,6 +2719,59 @@ mod thread_open_failure_tests {
         }
 
         *WEBSOCKET_SERVICE.lock() = None;
+    }
+
+    #[gpui::test]
+    async fn native_creation_timeout_emits_only_correlated_error(cx: &mut TestAppContext) {
+        let _guard = super::TEST_WEBSOCKET_SERVICE_GUARD.lock();
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+            language_model::init(cx);
+        });
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs.clone(), [], cx).await;
+        let thread_store = cx.new(|cx| ThreadStore::new(cx));
+        let agent = cx.update(|cx| {
+            agent::NativeAgent::new(thread_store, agent::Templates::new(), fs, cx)
+        });
+        let connection = Rc::new(agent::NativeAgentConnection(agent));
+        let (service, mut events) = WebSocketSync::new_test();
+        *WEBSOCKET_SERVICE.lock() = Some(service);
+
+        let task = cx.update(|cx| {
+            cx.spawn(async move |cx| {
+                create_native_session_when_ready(
+                    connection,
+                    project,
+                    "req-timeout".to_string(),
+                    cx.clone(),
+                )
+                .await
+            })
+        });
+        cx.run_until_parked();
+        cx.executor().advance_clock(Duration::from_secs(16));
+        cx.run_until_parked();
+        assert!(task.await.is_err());
+
+        let mut correlated_errors = 0;
+        while let Ok(event) = events.try_recv() {
+            match event {
+                SyncEvent::ChatResponseError { request_id, .. }
+                    if request_id == "req-timeout" =>
+                {
+                    correlated_errors += 1;
+                }
+                SyncEvent::ThreadCreated { .. } | SyncEvent::AgentReady { .. } => {
+                    panic!("timeout must not create or ready a thread")
+                }
+                _ => {}
+            }
+        }
+        *WEBSOCKET_SERVICE.lock() = None;
+
+        assert_eq!(correlated_errors, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Create NativeAgent sessions only when the exact configured provider/model is present in both the current registry and the NativeAgent private model cache.
- Keep the readiness check and session creation in one atomic GPUI update.
- Poll for up to 15 seconds, then emit only the request-correlated ChatResponseError.
- Leave the existing selector, fallback logic, and custom-agent path unchanged.

## Root cause

During Prime recovery of the exploding-kittens Chief of Staff, NativeAgent session creation raced model propagation. Settings already named anthropic/claude-opus-4-6, but the registry/private cache was not ready. Session creation therefore persisted the default OpenAI model and the subsequent request reached /v1/responses, which returned 404.

## Verification

- cargo test -p agent configured_session_uses_exact_cached_model -- --nocapture: passed, 1 test.
- cargo test -p external_websocket_sync native_creation_timeout_emits_only_correlated_error -- --nocapture: passed, 1 test.
- ./stack build-zed release: passed.
- ./stack build-ubuntu: passed.
- ./stack build-sandbox: passed.
- Live Prime task spt_01ky4fkhdtxhbge4fjd52gtb48 completed initial and follow-up turns with anthropic/claude-opus-4-6 on ACP thread 965840c7-0154-49f6-aaf1-7d9078595aa0. Logs showed no fallback, selector rewrite, or ChatResponseError.
- NOT tested live: forced 15-second readiness timeout, because inducing it on shared Prime was unsafe. The deterministic timeout test passed.
- NOT tested: macOS build and UI.

## Helix pin

https://github.com/helixml/helix/pull/2872