### PR TITLE
fix(e2e): use available Claude model

### DIFF
--- a/crates/external_websocket_sync/e2e-test/run_e2e.sh
+++ b/crates/external_websocket_sync/e2e-test/run_e2e.sh
@@ -229,7 +229,7 @@ ${AGENT_SERVERS_JSON}
   "agent": {
     "default_model": {
       "provider": "anthropic",
-      "model": "claude-sonnet-4-5-latest"
+      "model": "claude-sonnet-4-6"
     },
     "always_allow_tool_actions": true,
     "show_onboarding": false,


### PR DESCRIPTION
## Summary
- configure the E2E NativeAgent with the available claude-sonnet-4-6 model

## Testing
- full Docker E2E on Prime: Zed 17/17, Claude 17/17, store validation passed