### PR TITLE
test(e2e): bound deferred queue response

### DIFF
--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
@@ -1414,7 +1414,7 @@ func (d *testDriver) runQueuePhases() {
 		os.Exit(1)
 	}
 	// Agent is now busy on A. Enqueue B (interrupt=false): must be HELD.
-	promptB, err := d.srv.EnqueueQueuedPrompt(sessID, "Now also mention whales.", false)
+	promptB, err := d.srv.EnqueueQueuedPrompt(sessID, "Reply with exactly this one sentence: Whales are mammals.", false)
 	if err != nil {
 		log.Printf("[%s] Phase 16: ABORT — enqueue B failed: %v", agent, err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- bound Phase 16 deferred prompt B to one exact sentence
- preserve the production queue assertions while avoiding model-output-length timeouts

## Root cause
Drone builds 3124 and 3125 both dispatched prompt B correctly, but Claude expanded the unconstrained request into a long whale-enhanced 1-to-40 response and did not complete within the phase timeout. A previous green run took 58 seconds for the same prompt, already close to the 75-second wait.

## Verification
- ./run_docker_e2e.sh passed all 17 zed-agent phases
- E2E_AGENTS=zed-agent,claude ./run_docker_e2e.sh passed all 17 phases for both agents and store
- Claude Phase 16 returned the exact 19-byte response and passed

Helix pin PR: https://github.com/helixml/helix/pull/2891