### PR TITLE
test(external_websocket_sync): bound phase 9 response

### DIFF
--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
@@ -1009,10 +1009,10 @@ func (d *testDriver) runPhase9() {
 	d.round.phase9ThreadID = d.round.phase8ThreadID
 	d.mu.Unlock()
 
-	// Turn 1: start a long-running response. The syncEventCallback will
+	// Turn 1: start a bounded streaming response. The syncEventCallback will
 	// fire the rapid sequence as soon as the first assistant token arrives.
 	d.sendChatMessage(
-		"Write a detailed explanation of merge sort with code examples.",
+		"Output the numbers 1 through 100, one per line, and nothing else.",
 		d.round.reqID("phase9-initial"),
 		agent,
 		d.round.phase8ThreadID,


### PR DESCRIPTION
## Summary
- replace the unbounded Phase 9 essay prompt with a finite 1-through-100 stream
- preserve the first-token rapid cancellation sequence while removing provider output-length variance

## Validation
- full Docker E2E passed on Prime with E2E_AGENTS=zed-agent,claude
- Zed, Claude, and store validation passed
- Phase 9 rapid trigger fired during partial streaming for both agents
- Phase 9 completed in 5 seconds for Zed and 7 seconds for Claude