### PR TITLE
feat(headless): open path args as worktrees + add E2E smoke mode

### DIFF
--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
@@ -25,6 +25,13 @@
 //	          streaming-reveal task drains text into the markdown entity without re-emitting EntryUpdated,
 //	          so external_websocket_sync only sees stale snapshots until message_completed.)
 //
+// Smoke mode (E2E_SMOKE=1) replaces the phase chain above with a single phase:
+// the agent is asked to read a file holding a magic number and echo it back. It
+// proves the whole path end-to-end — WebSocket sync, ACP turn, agent tool call,
+// streamed response, interaction completion — for the price of one short turn.
+// It exists so CI can gate `zed --headless` on every build without burning the
+// tokens the full suite costs.
+//
 // Exit codes: 0 = all tests passed, 1 = test failure
 package main
 
@@ -213,7 +220,7 @@ func (d *testDriver) syncEventCallback(sessionID string, syncMsg *types.SyncMess
 			log.Printf("\n##################################################")
 			log.Printf("  ROUND %d/%d: Agent = %s", d.currentRoundIdx+1, len(d.agentRounds), d.round.agentName)
 			log.Printf("##################################################")
-			d.runPhase1()
+			d.startRound()
 			return
 		}
 
@@ -642,6 +649,41 @@ func (d *testDriver) sendQueryUiState(queryID string) {
 
 const phaseTimeout = 90 * time.Second
 
+// Smoke mode: a single tool-call phase instead of the full suite. See the
+// package comment. smokePhase is deliberately outside the 1..17 range so no
+// phase-numbered branch elsewhere can mistake it for a real phase.
+const (
+	smokePhase      = 100
+	smokeMagicValue = "4242"
+)
+
+var smokeMode = os.Getenv("E2E_SMOKE") == "1"
+
+// Absolute path, written by run_e2e.sh. Zed's file tools resolve a bare
+// relative path against the worktree name ("project/magic-number.txt"), so an
+// absolute path is the one form every agent resolves the same way.
+var smokeMagicFile = envOr("E2E_SMOKE_FILE", "/test/project/magic-number.txt")
+
+func envOr(name, fallback string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// The completion router filters on a "req-phase{N}-" prefix, so the smoke
+// request id has to follow the same convention or its completion is dropped.
+var smokeReqTag = fmt.Sprintf("phase%d", smokePhase)
+
+// startRound begins a round with either the smoke phase or the full phase chain.
+func (d *testDriver) startRound() {
+	if smokeMode {
+		d.runSmokePhase()
+		return
+	}
+	d.runPhase1()
+}
+
 // startPhaseTimeout launches a watchdog that fires if the current phase
 // doesn't complete within phaseTimeout. On timeout it dumps diagnostic
 // state and advances to the next round (failing the current one).
@@ -732,6 +774,8 @@ func (d *testDriver) advanceAfterCompletion(completedPhase int) {
 	d.mu.Unlock()
 
 	switch completedPhase {
+	case smokePhase:
+		d.advanceToNextRound()
 	case 1:
 		d.mu.Lock()
 		d.phase = 2
@@ -866,7 +910,60 @@ func (d *testDriver) advanceToNextRound() {
 	log.Printf("[test-server] Waiting 10s for previous round events to drain...")
 	time.Sleep(10 * time.Second)
 
-	d.runPhase1()
+	d.startRound()
+}
+
+// runSmokePhase asks the agent to read a file and echo the number inside it.
+// The value is not derivable from the prompt, so a correct answer proves the
+// agent actually ran a tool rather than guessing.
+func (d *testDriver) runSmokePhase() {
+	d.mu.Lock()
+	d.phase = smokePhase
+	agent := d.round.agentName
+	d.mu.Unlock()
+
+	log.Printf("\n==================================================")
+	log.Printf("  [%s] SMOKE: tool call + single value", agent)
+	log.Printf("==================================================")
+	d.startPhaseTimeout(smokePhase)
+	d.sendChatMessage(
+		"Use your file-reading tool to read the file "+smokeMagicFile+" at the root of this project. "+
+			"Do not search for it. Reply with only the number it contains.",
+		d.round.reqID(smokeReqTag), agent)
+}
+
+// validateSmokeRound checks the single smoke phase. Callers must hold d.mu.
+func (d *testDriver) validateSmokeRound() roundResult {
+	agent := d.round.agentName
+	var errors []string
+
+	if len(d.filterRoundEvents("thread_created")) < 1 {
+		errors = append(errors, "Smoke: no thread_created event")
+	}
+	if !d.hasRoundCompletion(d.round.reqID(smokeReqTag)) {
+		errors = append(errors, "Smoke: no message_completed for "+d.round.reqID(smokeReqTag))
+	}
+
+	// The magic value must appear in a completed response. Smoke mode runs one
+	// turn, and the interaction for a brand-new thread carries no PromptMessage
+	// (it is created by thread_created, before any prompt text is attached), so
+	// match on the response alone rather than trying to identify the prompt.
+	found := false
+	for _, i := range d.store.GetAllInteractions() {
+		if strings.Contains(i.ResponseMessage, smokeMagicValue) {
+			found = true
+			log.Printf("[%s] Smoke: ✅ agent returned %s via tool call (interaction %s, state=%s)",
+				agent, smokeMagicValue, truncate(i.ID, 12), i.State)
+			break
+		}
+		log.Printf("[%s] Smoke: interaction %s state=%s response=%q",
+			agent, truncate(i.ID, 12), i.State, truncate(i.ResponseMessage, 200))
+	}
+	if !found {
+		errors = append(errors, "Smoke: response never contained magic value "+smokeMagicValue)
+	}
+
+	return roundResult{agentName: agent, passed: len(errors) == 0, errors: errors}
 }
 
 func (d *testDriver) runPhase1() {
@@ -1511,6 +1608,10 @@ func (d *testDriver) validateRound() roundResult {
 	log.Printf("  VALIDATION: %s", agent)
 	log.Printf("==================================================")
 
+	if smokeMode {
+		return d.validateSmokeRound()
+	}
+
 	var errors []string
 
 	// --- Event-level validation ---
@@ -2139,7 +2240,12 @@ func (d *testDriver) validateStore() bool {
 	log.Printf("[store] Interactions in store: %d", len(interactions))
 
 	// Each round creates 5 threads (phases 1, 3, 8, 13, 15) = 5 sessions per round.
-	expectedSessions := 5 * len(d.agentRounds)
+	// Smoke mode runs one phase, so one thread/session per round.
+	perRoundSessions := 5
+	if smokeMode {
+		perRoundSessions = 1
+	}
+	expectedSessions := perRoundSessions * len(d.agentRounds)
 	if len(sessions) < expectedSessions {
 		errors = append(errors, fmt.Sprintf("Expected at least %d sessions (%d rounds * 4 threads), got %d",
 			expectedSessions, len(d.agentRounds), len(sessions)))
@@ -2262,13 +2368,18 @@ func (d *testDriver) validateStore() bool {
 	//   - Phase 9:  on-the-fly interaction (from user interrupt)
 	//   - Phase 11: sendChatMessageToExternalAgent via spectask routing
 	//   - Phase 15: thread_created → new session + interaction (streaming-cadence)
-	expectedCompleted := 8 * len(d.agentRounds)
+	// Smoke mode runs a single turn per round, so one of each.
+	perRoundCompleted := 8
+	if smokeMode {
+		perRoundCompleted = 1
+	}
+	expectedCompleted := perRoundCompleted * len(d.agentRounds)
 	if completedInteractions < expectedCompleted {
 		errors = append(errors, fmt.Sprintf("Expected at least %d completed interactions, got %d", expectedCompleted, completedInteractions))
 	}
 
 	// Expect at least 8 interactions WITH content per round.
-	expectedWithContent := 8 * len(d.agentRounds)
+	expectedWithContent := perRoundCompleted * len(d.agentRounds)
 	if completedWithContent < expectedWithContent {
 		errors = append(errors, fmt.Sprintf("Expected at least %d completed interactions with content, got %d (accumulation may be broken)",
 			expectedWithContent, completedWithContent))

--- a/crates/external_websocket_sync/e2e-test/run_docker_e2e.sh
+++ b/crates/external_websocket_sync/e2e-test/run_docker_e2e.sh
@@ -111,6 +111,7 @@ if [ -n "${ANTHROPIC_BASE_URL:-}" ]; then
     ANTHROPIC_BASE_URL_ARG="-e ANTHROPIC_BASE_URL=$ANTHROPIC_BASE_URL"
 fi
 
+E2E_RC=0
 docker run --rm \
     --add-host=host.docker.internal:host-gateway \
     -e ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" \
@@ -118,13 +119,24 @@ docker run --rm \
     ${ANTHROPIC_BASE_URL_ARG} \
     -e E2E_AGENTS="$E2E_AGENTS" \
     -e E2E_HEADLESS="${E2E_HEADLESS:-0}" \
+    -e E2E_SMOKE="${E2E_SMOKE:-0}" \
+    -e E2E_SMOKE_FILE="${E2E_SMOKE_FILE:-}" \
+    -e E2E_CODEX_MODEL="${E2E_CODEX_MODEL:-}" \
+    -e E2E_MODEL_PROVIDER="${E2E_MODEL_PROVIDER:-}" \
+    -e E2E_MODEL="${E2E_MODEL:-}" \
+    -e E2E_REASONING_EFFORT="${E2E_REASONING_EFFORT:-}" \
     -e HELIX_ACP_SILENCE_TIMEOUT_SECS="${HELIX_ACP_SILENCE_TIMEOUT_SECS:-}" \
     -v "$SCREENSHOTS_DIR:/test/screenshots" \
     $CLAUDE_ACP_MOUNT \
-    zed-ws-e2e
+    zed-ws-e2e || E2E_RC=$?
 
-# Report screenshots
-SHOT_COUNT=$(ls -1 "$SCREENSHOTS_DIR"/*.png 2>/dev/null | wc -l || echo 0)
+# Report screenshots.
+# The fallback belongs on the ASSIGNMENT, not inside the substitution: `ls` exits
+# non-zero when the glob matches nothing (a headless run captures no
+# screenshots), `set -o pipefail` propagates that through `| wc -l`, and `set -e`
+# then kills the script. Putting `|| echo 0` inside the substitution instead
+# yields the two-line string "0\n0", which breaks the `-gt` test below.
+SHOT_COUNT=$(ls -1 "$SCREENSHOTS_DIR"/*.png 2>/dev/null | wc -l) || SHOT_COUNT=0
 if [ "$SHOT_COUNT" -gt 0 ]; then
     echo ""
     echo "=== Screenshots ==="
@@ -132,3 +144,9 @@ if [ "$SHOT_COUNT" -gt 0 ]; then
     ls -lh "$SCREENSHOTS_DIR"/*.png | tail -5
     echo "(showing last 5)"
 fi
+
+# Exit with the test's status, not whatever the reporting above happened to
+# return. A headless run captures no screenshots, so the trailing `[ -gt ]` was
+# the script's last command and its status became the script's — reporting a
+# failure for a test that passed.
+exit "$E2E_RC"

--- a/crates/external_websocket_sync/e2e-test/run_e2e.sh
+++ b/crates/external_websocket_sync/e2e-test/run_e2e.sh
@@ -94,9 +94,20 @@ cleanup() {
 
     # Report screenshots
     if [ -d "$SCREENSHOT_DIR" ]; then
-        SHOT_COUNT=$(ls -1 "$SCREENSHOT_DIR"/*.png 2>/dev/null | wc -l)
+        # `ls` exits non-zero when the glob matches nothing, and `set -o pipefail`
+        # propagates that through `| wc -l` to the ASSIGNMENT — which `set -e`
+        # then treats as fatal, aborting this trap mid-way. Put the fallback on
+        # the assignment (same shape as the grep -c cases above).
+        SHOT_COUNT=$(ls -1 "$SCREENSHOT_DIR"/*.png 2>/dev/null | wc -l) || SHOT_COUNT=0
         echo "[screenshots] Captured $SHOT_COUNT screenshots in $SCREENSHOT_DIR"
     fi
+
+    # The script runs under `set -e`, and a non-zero status from the LAST command
+    # in an EXIT trap replaces the script's own exit status. Every command above
+    # is diagnostics — a failing grep/cp/test must never turn a PASSING run into
+    # a failure (headless runs captured no screenshots and exited 2 this way).
+    # `return 0` here leaves a real `exit 1` from the test intact; verified.
+    return 0
 }
 trap cleanup EXIT
 
@@ -168,6 +179,24 @@ echo "[setup] Zed binary: $ZED_BINARY"
 echo "[setup] Mock server: $MOCK_SERVER"
 echo "[setup] Timeout: ${TEST_TIMEOUT}s"
 echo ""
+
+# ---- Smoke mode ----
+# E2E_SMOKE=1 runs a single tool-call phase instead of the full suite: the agent
+# reads magic-number.txt and echoes the value. Cheap enough to gate every CI
+# build on. The value is not in the prompt, so it can only come from a tool call.
+export E2E_SMOKE="${E2E_SMOKE:-0}"
+if [ "$E2E_SMOKE" = "1" ]; then
+    if [ -z "${E2E_SMOKE_FILE:-}" ]; then
+        export E2E_SMOKE_FILE="$PROJECT_DIR/magic-number.txt"
+        echo "4242" > "$E2E_SMOKE_FILE"
+        echo "[setup] E2E_SMOKE=1: wrote $E2E_SMOKE_FILE (single tool-call phase)"
+    else
+        # Caller pointed the smoke test at their own file — don't create it.
+        # Pointing it at a path that does not exist is how you verify the gate
+        # can actually fail.
+        echo "[setup] E2E_SMOKE=1: using caller-provided E2E_SMOKE_FILE=$E2E_SMOKE_FILE"
+    fi
+fi
 
 # ---- Start Go WebSocket Test Server ----
 echo "[mock-server] Starting Go test server (shares wsprotocol with production Helix)..."
@@ -264,11 +293,15 @@ if echo "$E2E_AGENTS" | grep -q "codex"; then
     CODEX_ACP_PKG="@agentclientprotocol/codex-acp"
     CODEX_ACP_VERSION=$(npm view "$CODEX_ACP_PKG" version 2>/dev/null || echo "unknown")
     echo "[setup] Using npm-installed codex-acp $CODEX_ACP_PKG (auto-install, latest=$CODEX_ACP_VERSION)"
+    # codex-acp model ids are "model[effort]" (ModelId.fromString in the package).
+    # E2E_CODEX_MODEL lets CI pick a cheaper model/effort than the local default.
+    CODEX_MODEL="${E2E_CODEX_MODEL:-gpt-5.6-terra}"
+    echo "[setup] Codex model: $CODEX_MODEL"
     AGENT_SERVER_ENTRIES="${AGENT_SERVER_ENTRIES}
     \"codex-acp\": {
       \"type\": \"registry\",
       \"default_mode\": \"agent-full-access\",
-      \"default_model\": \"gpt-5.6-terra\",
+      \"default_model\": \"${CODEX_MODEL}\",
       \"env\": {
         \"OPENAI_API_KEY\": \"${CODEX_KEY}\"
       }
@@ -285,18 +318,55 @@ AGENTEOF
 )
 fi
 
+# ---- Native (zed-agent) model selection ----
+# Defaults keep the historical Anthropic config. E2E_MODEL_PROVIDER=openai lets
+# CI drive the native agent from an OpenAI model instead — the OpenAI provider
+# accepts an explicit available_models entry, so new model ids work without a
+# Zed release.
+#
+# reasoning_effort defaults to "none" because Zed's OpenAI provider talks to
+# /v1/chat/completions, and that endpoint rejects any other effort when the
+# request carries function tools ("use /v1/responses or set reasoning_effort to
+# 'none'"). The smoke test needs tools, so "none" is the only working value —
+# and the cheapest.
+E2E_MODEL_PROVIDER="${E2E_MODEL_PROVIDER:-anthropic}"
+if [ "$E2E_MODEL_PROVIDER" = "openai" ]; then
+    E2E_MODEL="${E2E_MODEL:-gpt-5.6-luna}"
+    LANGUAGE_MODELS_JSON=$(cat << MODELEOF
+    "openai": {
+      "api_url": "${OPENAI_BASE_URL:-https://api.openai.com/v1}",
+      "available_models": [
+        {
+          "name": "${E2E_MODEL}",
+          "display_name": "${E2E_MODEL}",
+          "max_tokens": 128000,
+          "reasoning_effort": "${E2E_REASONING_EFFORT:-none}"
+        }
+      ]
+    }
+MODELEOF
+)
+else
+    E2E_MODEL="${E2E_MODEL:-claude-sonnet-4-6}"
+    LANGUAGE_MODELS_JSON=$(cat << MODELEOF
+    "anthropic": {
+      "api_url": "${ANTHROPIC_BASE_URL:-https://api.anthropic.com}"
+    }
+MODELEOF
+)
+fi
+echo "[setup] Native agent model: ${E2E_MODEL_PROVIDER}/${E2E_MODEL}"
+
 cat > "$ZED_CONFIG_DIR/settings.json" << JSONEOF
 {
 ${AGENT_SERVERS_JSON}
   "language_models": {
-    "anthropic": {
-      "api_url": "${ANTHROPIC_BASE_URL:-https://api.anthropic.com}"
-    }
+${LANGUAGE_MODELS_JSON}
   },
   "agent": {
     "default_model": {
-      "provider": "anthropic",
-      "model": "claude-sonnet-4-6"
+      "provider": "${E2E_MODEL_PROVIDER}",
+      "model": "${E2E_MODEL}"
     },
     "always_allow_tool_actions": true,
     "show_onboarding": false,

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -882,7 +882,7 @@ fn main() {
         .detach_and_log_err(cx);
 
         if args.headless {
-            initialize_headless(app_state.clone(), cx);
+            initialize_headless(app_state.clone(), args.paths_or_urls.clone(), cx);
             return;
         }
 
@@ -1406,12 +1406,13 @@ async fn installation_id(db: KeyValueStore) -> Result<IdType> {
 /// Initialize Zed in headless mode: no windows, no workspace.
 ///
 /// Sets up the external WebSocket sync (Helix) and the agent thread handler so the
-/// process can drive ACP threads from the WebSocket without any UI. The GPUI event
-/// loop continues running until the process is signalled.
+/// process can drive ACP threads from the WebSocket without any UI, and opens each
+/// path argument as a worktree so agent file tools can reach the repo. The GPUI
+/// event loop continues running until the process is signalled.
 ///
 /// Without `external_websocket_sync` enabled this is effectively a no-op idle loop —
 /// the flag is mostly useful for the Helix integration.
-fn initialize_headless(app_state: Arc<AppState>, cx: &mut App) {
+fn initialize_headless(app_state: Arc<AppState>, paths: Vec<String>, cx: &mut App) {
     log::info!("🟢 [HEADLESS] Starting Zed in headless mode (no windows, no display)");
     eprintln!("🟢 [HEADLESS] Starting Zed in headless mode (no windows, no display)");
 
@@ -1437,6 +1438,36 @@ fn initialize_headless(app_state: Arc<AppState>, cx: &mut App) {
             },
             cx,
         );
+
+        // Open the paths from the command line as worktrees. Headless mode skips
+        // restore_or_create_workspace, and it is the workspace that normally turns
+        // a path argument into a worktree — so without this the project is empty
+        // and every agent file tool fails with "Path ... is not in the project".
+        for path in paths {
+            let abs_path = std::path::PathBuf::from(&path);
+            let abs_path = if abs_path.is_absolute() {
+                abs_path
+            } else {
+                match std::env::current_dir() {
+                    Ok(cwd) => cwd.join(abs_path),
+                    Err(e) => {
+                        log::error!("🔴 [HEADLESS] cannot resolve {path:?} against cwd: {e:#}");
+                        continue;
+                    }
+                }
+            };
+            let task = project.update(cx, |project, cx| {
+                project.find_or_create_worktree(abs_path.clone(), true, cx)
+            });
+            cx.spawn(async move |_| match task.await {
+                Ok(_) => log::info!("🟢 [HEADLESS] Opened worktree {}", abs_path.display()),
+                Err(e) => log::error!(
+                    "🔴 [HEADLESS] Failed to open worktree {}: {e:#}",
+                    abs_path.display()
+                ),
+            })
+            .detach();
+        }
 
         let thread_store = agent::ThreadStore::global(cx);
 
@@ -1560,6 +1591,7 @@ fn initialize_headless(app_state: Arc<AppState>, cx: &mut App) {
     #[cfg(not(feature = "external_websocket_sync"))]
     {
         let _ = app_state;
+        let _ = paths;
         let _ = cx;
         log::warn!(
             "🟡 [HEADLESS] Built without `external_websocket_sync` feature; --headless has nothing to do"

--- a/portingguide.md
+++ b/portingguide.md
@@ -438,11 +438,19 @@ if !stopped_emitted_for_task.load(std::sync::atomic::Ordering::Acquire) {
 It still:
 - Initializes `external_websocket_sync` and connects to Helix (when settings enable it).
 - Wires up the thread service handler over a windowless `Project::local`.
+- Opens each path argument as a worktree, so agent file tools work.
 - Runs the GPUI event loop until interrupted, so MCP/agent turns can stream as normal.
 
 What it deliberately skips:
 - `restore_or_create_workspace` — no `MultiWorkspace`/`Workspace`/`Window` is ever opened.
 - `OpenListener` second-instance handling (`--headless` implies `--allow-multiple-instances`).
+
+**Worktrees are not free in headless mode.** It is `restore_or_create_workspace` that
+normally turns `zed <path>` into a worktree, and headless skips it — so
+`initialize_headless()` calls `find_or_create_worktree()` for each path argument itself.
+Without that the project is empty and every agent file tool fails with
+`Path ... is not in the project`, while chat-only turns still look perfectly healthy.
+That is why the CI gate below asserts a **tool call**, not just a reply.
 
 Use cases: running Zed as a Helix agent backend on a server with no GUI; running inside a
 container that doesn't have Sway/Hyprland/X11; smoke-testing the WebSocket protocol without
@@ -473,17 +481,41 @@ UI-state responder that returns `active_view: "headless"` plus the real
 `thread_id`, `entry_count`, and `active_model` are reported as null/0 (the
 panel is the source of those in headful mode and we don't track them here).
 
-**Recommended CI matrix** — covers both agents and both display modes without
-spending more wall-clock than the original single-mode default:
+### Smoke mode (`E2E_SMOKE=1`) — the CI gate
 
-| Job | Command | Runs | Time |
-|-----|---------|------|------|
-| `e2e-headful` | `./run_docker_e2e.sh` | zed-agent (headful, full 12 phases) | ~3–4 min |
-| `e2e-headless` | `E2E_HEADLESS=1 E2E_AGENTS=claude ./run_docker_e2e.sh` | claude (headless, full 12 phases) | ~3–4 min |
+The full suite costs a lot of tokens, which is why it was gated to main + tags
+and headless was never gated at all. `E2E_SMOKE=1` replaces the phase chain with
+a single phase: the agent reads `magic-number.txt` and replies with the value.
+One short turn covers WebSocket sync, worktree setup, an agent tool call,
+streaming and interaction completion. The value never appears in the prompt, so
+only a real tool call can produce it.
 
-Run them as parallel CI jobs and total wall clock stays at ~3–4 min. If you
-want to test both agents in both modes, expand to a 4-cell matrix. The
-`E2E_AGENTS` and `E2E_HEADLESS` env vars compose freely.
+```bash
+E2E_HEADLESS=1 E2E_SMOKE=1 E2E_AGENTS=zed-agent \
+  E2E_MODEL_PROVIDER=openai E2E_MODEL=gpt-5.6-luna ./run_docker_e2e.sh
+```
+
+Knobs (all optional, all default to today's behaviour):
+
+| Env | Default | Purpose |
+|-----|---------|---------|
+| `E2E_SMOKE` | `0` | Single tool-call phase instead of the full suite |
+| `E2E_SMOKE_FILE` | `<project>/magic-number.txt` | Absolute path the agent is told to read |
+| `E2E_MODEL_PROVIDER` | `anthropic` | Native-agent provider (`openai` emits an `available_models` entry) |
+| `E2E_MODEL` | `claude-sonnet-4-6` | Native-agent model id |
+| `E2E_REASONING_EFFORT` | `none` | OpenAI only. Must stay `none`: `/v1/chat/completions` rejects any other effort when the request carries function tools |
+| `E2E_CODEX_MODEL` | `gpt-5.6-terra` | codex-acp model id, `model[effort]` form |
+
+Helix CI (`.drone.yml`) runs `zed-e2e-headless-smoke` on **every push including
+PRs**, and the full `zed-e2e-test` on main + tags. Both share the image built by
+`zed-e2e-image`.
+
+**Note on codex in containers.** `E2E_AGENTS=codex` cannot do tool calls inside
+the E2E image: codex sandboxes commands with bubblewrap, which fails with
+`bwrap: No permissions to create new namespace` in an unprivileged container.
+The turn then hangs waiting for an approval nobody answers. Chat-only phases are
+unaffected — which is why the full codex round passes while a tool-call phase
+does not. Use `zed-agent` for the tool-call gate.
 
 ## Callback Architecture
 


### PR DESCRIPTION
## The bug

`zed --headless` never opened a worktree. `restore_or_create_workspace` is what normally turns `zed <path>` into one, and headless deliberately skips it — so the project was empty and **every agent file tool failed** with `Path ... is not in the project`.

Chat-only turns looked completely healthy, which is why this survived: the 17-phase E2E suite is all arithmetic prompts, so it never touched a file. `initialize_headless()` now calls `find_or_create_worktree()` for each path argument.

Without this, headless mode can chat but cannot do work — no reading or editing the repo.

## The gate

`E2E_SMOKE=1` runs a single phase: the agent reads `magic-number.txt` and replies with the value. One short turn covers WebSocket sync, worktree setup, an agent tool call, streaming and interaction completion. The value is not in the prompt, so only a real tool call produces it.

Verified in both directions:
- passes on a real tool call (`Smoke: ✅ agent returned 4242 via tool call`, exit 0)
- **fails, exit 1**, when pointed at a missing file (`response never contained magic value 4242`)
- 20/20 consecutive runs, ~15s each

Helix CI runs it on every push including PRs (helixml/helix#2975); the full suite stays on main + tags.

## Model knobs

`E2E_MODEL_PROVIDER=openai` emits an `available_models` entry, so new model ids work without a Zed release. `E2E_CODEX_MODEL` takes codex-acp's `model[effort]` form. `reasoning_effort` defaults to `none` — Zed's OpenAI provider uses `/v1/chat/completions`, which rejects any other effort when the request carries function tools. All defaults preserve today's behaviour.

## Harness fixes

Two bugs that made a **passing** headless run report failure:
- `ls -1 dir/*.png | wc -l` fails under `set -o pipefail` when nothing matches; that killed the EXIT trap mid-way, and the trap's status replaced the script's `exit 0` (exit 2).
- `run_docker_e2e.sh` exited with the status of its trailing screenshot check rather than the test's.

## Note on codex

`E2E_AGENTS=codex` cannot do tool calls inside the E2E image: codex sandboxes commands with bubblewrap, which fails with `bwrap: No permissions to create new namespace` in an unprivileged container, and the turn then hangs waiting for an approval nobody answers. Chat-only phases are unaffected — the full codex round passes. Documented in `portingguide.md`; the gate uses `zed-agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)