### PR TITLE
feat(agent): sync ACP plans to Helix

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -2207,6 +2207,7 @@ pub enum AcpThreadEvent {
     ModeUpdated(acp::SessionModeId),
     ConfigOptionsUpdated(Vec<acp::SessionConfigOption>),
     WorkingDirectoriesUpdated,
+    PlanUpdated,
 }
 
 impl EventEmitter<AcpThreadEvent> for AcpThread {}
@@ -3636,6 +3637,7 @@ impl AcpThread {
         }
         self.plan.entries.truncate(new_entries_len);
 
+        cx.emit(AcpThreadEvent::PlanUpdated);
         cx.notify();
     }
 
@@ -3655,6 +3657,7 @@ impl AcpThread {
 
     pub fn clear_plan(&mut self, cx: &mut Context<Self>) {
         self.plan.entries.clear();
+        cx.emit(AcpThreadEvent::PlanUpdated);
         cx.notify();
     }
 

--- a/crates/agent_ui/src/agent_diff.rs
+++ b/crates/agent_ui/src/agent_diff.rs
@@ -1496,6 +1496,7 @@ impl AgentDiff {
             | AcpThreadEvent::ModeUpdated(_)
             | AcpThreadEvent::ConfigOptionsUpdated(_)
             | AcpThreadEvent::WorkingDirectoriesUpdated
+            | AcpThreadEvent::PlanUpdated
             | AcpThreadEvent::PromptUpdated => {}
         }
     }

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -328,6 +328,7 @@ impl Conversation {
                     | AcpThreadEvent::ModeUpdated(_)
                     | AcpThreadEvent::ConfigOptionsUpdated(_)
                     | AcpThreadEvent::WorkingDirectoriesUpdated
+                    | AcpThreadEvent::PlanUpdated
                     | AcpThreadEvent::PromptUpdated => {}
                 }
             }
@@ -582,6 +583,7 @@ fn affects_thread_metadata(event: &AcpThreadEvent) -> bool {
         | AcpThreadEvent::ModeUpdated(_)
         | AcpThreadEvent::ConfigOptionsUpdated(_)
         | AcpThreadEvent::SubagentSpawned(_)
+        | AcpThreadEvent::PlanUpdated
         | AcpThreadEvent::PromptUpdated => false,
     }
 }
@@ -2260,6 +2262,9 @@ impl ConversationView {
                 cx.notify();
             }
             AcpThreadEvent::WorkingDirectoriesUpdated => {
+                cx.notify();
+            }
+            AcpThreadEvent::PlanUpdated => {
                 cx.notify();
             }
             AcpThreadEvent::PromptUpdated => {

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -850,9 +850,10 @@ pub fn get_thread(acp_thread_id: &str) -> Option<WeakEntity<AcpThread>> {
 /// that create or load threads must call this to set up the subscription. It is
 /// idempotent — if a persistent subscription already exists, it does nothing.
 ///
-/// Handles four events:
+/// Handles five events:
 /// - `NewEntry`: new user/assistant message → send `message_added`
 /// - `EntryUpdated`: streaming tokens / tool call updates → throttled `message_added`
+/// - `PlanUpdated`: ACP plans/TodoWrite updates → structured `message_added`
 /// - `Stopped`: turn completed → flush throttle + send `message_completed`
 /// - `Error`: turn aborted (agent process exited mid-turn, or MaxTokens) →
 ///   flush + send `chat_response_error` so Helix errors the interaction
@@ -1093,6 +1094,49 @@ pub fn ensure_thread_subscription(
                         &tool_status,
                     );
                 }
+            }
+            AcpThreadEvent::PlanUpdated => {
+                let thread = thread_entity.read(cx);
+                let steps = thread
+                    .plan()
+                    .entries
+                    .iter()
+                    .map(|entry| {
+                        let status = match entry.status {
+                            acp::PlanEntryStatus::Completed => "completed",
+                            acp::PlanEntryStatus::InProgress => "inProgress",
+                            _ => "pending",
+                        };
+                        serde_json::json!({
+                            "step": entry.content.read(cx).source().to_string(),
+                            "status": status,
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                let content = serde_json::json!({ "steps": steps }).to_string();
+
+                // A plan can arrive before the first assistant entry. In that
+                // case the turn-scoped id still belongs to the completed turn,
+                // while THREAD_REQUEST_MAP already contains the current one.
+                let captured = turn_request_id.borrow().clone();
+                let last_completed = last_completed_request_id.borrow().clone();
+                let rid = if captured.is_empty() || captured == last_completed {
+                    crate::get_thread_request_id(&thread_id_for_sub).unwrap_or_default()
+                } else {
+                    captured
+                };
+
+                crate::send_websocket_event(SyncEvent::MessageAdded {
+                    acp_thread_id: thread_id_for_sub.clone(),
+                    message_id: "plan".to_string(),
+                    role: "assistant".to_string(),
+                    content,
+                    request_id: rid,
+                    entry_type: "plan".to_string(),
+                    tool_name: String::new(),
+                    tool_status: String::new(),
+                    timestamp: chrono::Utc::now().timestamp(),
+                }).log_err();
             }
             // Stopped and Error are both turn-terminal and must send Helix a
             // terminal frame to free the activation lane. Stopped → completed;


### PR DESCRIPTION
## What changed

- expose ACP plan updates from the agent thread
- propagate plan updates through the agent UI event bridge
- serialize each plan snapshot into a stable structured `message_added` event for Helix
- correlate plans that arrive before assistant prose with the active request

Companion Helix PR: https://github.com/helixml/helix/pull/3001

## Why

Helix could not render live agent plans because Zed did not forward ACP plan updates through the external WebSocket sync. Treating the plan as a stable structured entry also lets Helix replace snapshots instead of accumulating duplicates.

## Impact

Claude Code, Codex, and other ACP agents can surface live plan progress in Helix without leaking raw plan JSON into assistant prose.

## Validation

- `cargo check -p external_websocket_sync`
- `git diff --check origin/main...HEAD`

The crate has broad pre-existing rustfmt differences, so repository-wide `cargo fmt --check` is not a usable branch-specific gate.