### PR TITLE
fix(acp): reset plans between prompt turns

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -3648,13 +3648,6 @@ impl AcpThread {
         }
     }
 
-    fn clear_completed_plan_entries(&mut self, cx: &mut Context<Self>) {
-        self.plan
-            .entries
-            .retain(|entry| !matches!(entry.status, acp::PlanEntryStatus::Completed));
-        cx.notify();
-    }
-
     pub fn clear_plan(&mut self, cx: &mut Context<Self>) {
         self.plan.entries.clear();
         cx.emit(AcpThreadEvent::PlanUpdated);
@@ -3779,7 +3772,12 @@ impl AcpThread {
         cx: &mut Context<Self>,
         f: impl 'static + AsyncFnOnce(WeakEntity<Self>, &mut AsyncApp) -> Result<acp::PromptResponse>,
     ) -> BoxFuture<'static, Result<Option<acp::PromptResponse>>> {
-        self.clear_completed_plan_entries(cx);
+        // Plans are scoped to a single prompt turn. Keeping pending entries here
+        // makes a follow-up prompt inherit the previous turn's unfinished plan,
+        // even when the agent does not publish a plan for the new work.
+        // Emit the empty snapshot before starting the turn so external clients
+        // can clear their persisted plan entry as well.
+        self.clear_plan(cx);
         self.had_error = false;
 
         self.turn_token_usage = None;

--- a/crates/external_websocket_sync/e2e-test/.gitignore
+++ b/crates/external_websocket_sync/e2e-test/.gitignore
@@ -2,6 +2,7 @@
 zed-binary
 helix-ws-test-server/helix-ws-test-server
 slow-mcp-server/slow-mcp-server
+plan-test-agent/plan-test-agent
 
 # Test artifacts
 screenshots/

--- a/crates/external_websocket_sync/e2e-test/Dockerfile.ci
+++ b/crates/external_websocket_sync/e2e-test/Dockerfile.ci
@@ -30,7 +30,13 @@ COPY slow-mcp-server /app
 WORKDIR /app
 RUN CGO_ENABLED=0 go build -o /slow-mcp-server .
 
-# Stage 3: Runtime
+# Stage 3: Build the deterministic ACP plan agent.
+FROM golang:1.25-alpine AS plan-agent-builder
+COPY plan-test-agent /app
+WORKDIR /app
+RUN CGO_ENABLED=0 go build -o /plan-test-agent .
+
+# Stage 4: Runtime
 FROM ubuntu:25.10
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -50,8 +56,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=go-builder /helix-ws-test-server /usr/local/bin/helix-ws-test-server
 COPY --from=mcp-builder /slow-mcp-server /usr/local/bin/slow-mcp-server
+COPY --from=plan-agent-builder /plan-test-agent /usr/local/bin/plan-test-agent
 COPY zed-binary /usr/local/bin/zed
-RUN chmod +x /usr/local/bin/zed /usr/local/bin/helix-ws-test-server /usr/local/bin/slow-mcp-server
+RUN chmod +x /usr/local/bin/zed /usr/local/bin/helix-ws-test-server /usr/local/bin/slow-mcp-server /usr/local/bin/plan-test-agent
 COPY run_e2e.sh /test/run_e2e.sh
 RUN chmod +x /test/run_e2e.sh
 ENV DISPLAY=:99

--- a/crates/external_websocket_sync/e2e-test/Dockerfile.runtime
+++ b/crates/external_websocket_sync/e2e-test/Dockerfile.runtime
@@ -40,7 +40,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY zed-binary /usr/local/bin/zed
 COPY helix-ws-test-server/helix-ws-test-server /usr/local/bin/helix-ws-test-server
 COPY slow-mcp-server/slow-mcp-server /usr/local/bin/slow-mcp-server
-RUN chmod +x /usr/local/bin/zed /usr/local/bin/helix-ws-test-server /usr/local/bin/slow-mcp-server
+COPY plan-test-agent/plan-test-agent /usr/local/bin/plan-test-agent
+RUN chmod +x /usr/local/bin/zed /usr/local/bin/helix-ws-test-server /usr/local/bin/slow-mcp-server /usr/local/bin/plan-test-agent
 
 # Copy test script
 COPY run_e2e.sh /test/run_e2e.sh

--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
@@ -32,6 +32,11 @@
 // It exists so CI can gate `zed --headless` on every build without burning the
 // tokens the full suite costs.
 //
+// Plan mode (E2E_PLAN=1) uses a deterministic ACP agent for two turns. The
+// first publishes a plan and the second publishes no plan. It verifies that a
+// new turn emits an empty plan snapshot and does not persist the prior turn's
+// steps in the new interaction.
+//
 // Exit codes: 0 = all tests passed, 1 = test failure
 package main
 
@@ -728,9 +733,12 @@ const phaseTimeout = 90 * time.Second
 const (
 	smokePhase      = 100
 	smokeMagicValue = "4242"
+	planFirstPhase  = 101
+	planSecondPhase = 102
 )
 
 var smokeMode = os.Getenv("E2E_SMOKE") == "1"
+var planMode = os.Getenv("E2E_PLAN") == "1"
 
 // Absolute path, written by run_e2e.sh. Zed's file tools resolve a bare
 // relative path against the worktree name ("project/magic-number.txt"), so an
@@ -752,6 +760,10 @@ var smokeReqTag = fmt.Sprintf("phase%d", smokePhase)
 func (d *testDriver) startRound() {
 	if smokeMode {
 		d.runSmokePhase()
+		return
+	}
+	if planMode {
+		d.runPlanFirstPhase()
 		return
 	}
 	d.runPhase1()
@@ -867,6 +879,13 @@ func (d *testDriver) advanceAfterCompletion(completedPhase int) {
 
 	switch completedPhase {
 	case smokePhase:
+		d.advanceToNextRound()
+	case planFirstPhase:
+		d.mu.Lock()
+		d.phase = planSecondPhase
+		d.mu.Unlock()
+		d.runPlanSecondPhase()
+	case planSecondPhase:
 		d.advanceToNextRound()
 	case 1:
 		d.mu.Lock()
@@ -1025,6 +1044,37 @@ func (d *testDriver) runSmokePhase() {
 		d.round.reqID(smokeReqTag), agent)
 }
 
+func (d *testDriver) runPlanFirstPhase() {
+	d.mu.Lock()
+	d.phase = planFirstPhase
+	agent := d.round.agentName
+	d.mu.Unlock()
+
+	log.Printf("\n==================================================")
+	log.Printf("  [%s] PLAN TURN 1: publish plan snapshots", agent)
+	log.Printf("==================================================")
+	d.startPhaseTimeout(planFirstPhase)
+	d.sendChatMessage("Publish the deterministic first-turn plan.", d.round.reqID("phase101"), agent)
+}
+
+func (d *testDriver) runPlanSecondPhase() {
+	d.mu.Lock()
+	agent := d.round.agentName
+	if len(d.round.threadIDs) == 0 {
+		d.mu.Unlock()
+		log.Printf("[%s] PLAN TURN 2: no thread from turn 1", agent)
+		os.Exit(1)
+	}
+	threadID := d.round.threadIDs[0]
+	d.mu.Unlock()
+
+	log.Printf("\n==================================================")
+	log.Printf("  [%s] PLAN TURN 2: no plan (must clear turn 1)", agent)
+	log.Printf("==================================================")
+	d.startPhaseTimeout(planSecondPhase)
+	d.sendChatMessage("Reply without publishing a plan.", d.round.reqID("phase102"), agent, threadID)
+}
+
 // validateSmokeRound checks the single smoke phase. Callers must hold d.mu.
 func (d *testDriver) validateSmokeRound() roundResult {
 	agent := d.round.agentName
@@ -1054,6 +1104,87 @@ func (d *testDriver) validateSmokeRound() roundResult {
 	}
 	if !found {
 		errors = append(errors, "Smoke: response never contained magic value "+smokeMagicValue)
+	}
+
+	return roundResult{agentName: agent, passed: len(errors) == 0, errors: errors}
+}
+
+func planEntries(interaction *types.Interaction) ([]map[string]interface{}, error) {
+	var entries []struct {
+		Type    string `json:"type"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(interaction.ResponseEntries, &entries); err != nil {
+		return nil, err
+	}
+	for _, entry := range entries {
+		if entry.Type != "plan" {
+			continue
+		}
+		var payload struct {
+			Steps []map[string]interface{} `json:"steps"`
+		}
+		if err := json.Unmarshal([]byte(entry.Content), &payload); err != nil {
+			return nil, err
+		}
+		return payload.Steps, nil
+	}
+	return nil, fmt.Errorf("no plan entry")
+}
+
+func (d *testDriver) validatePlanRound() roundResult {
+	agent := d.round.agentName
+	var errors []string
+
+	if len(d.filterRoundEvents("thread_created")) != 1 {
+		errors = append(errors, fmt.Sprintf("Plan: expected one thread, got %d", len(d.filterRoundEvents("thread_created"))))
+	}
+	if !d.hasRoundCompletion(d.round.reqID("phase101")) {
+		errors = append(errors, "Plan: first turn did not complete")
+	}
+	if !d.hasRoundCompletion(d.round.reqID("phase102")) {
+		errors = append(errors, "Plan: second turn did not complete")
+	}
+
+	foundEmptyResetEvent := false
+	for _, event := range d.round.events {
+		if event.EventType != "message_added" || event.Data["request_id"] != d.round.reqID("phase102") || event.Data["entry_type"] != "plan" {
+			continue
+		}
+		content, _ := event.Data["content"].(string)
+		if strings.Contains(content, `"steps":[]`) {
+			foundEmptyResetEvent = true
+		}
+	}
+	if !foundEmptyResetEvent {
+		errors = append(errors, "Plan: second turn did not emit an empty plan snapshot")
+	}
+
+	var first, second *types.Interaction
+	for _, interaction := range d.store.GetAllInteractions() {
+		switch {
+		case strings.Contains(interaction.ResponseMessage, "First turn complete."):
+			first = interaction
+		case strings.Contains(interaction.ResponseMessage, "Second turn has no plan."):
+			second = interaction
+		}
+	}
+	if first == nil {
+		errors = append(errors, "Plan: first interaction was not persisted")
+	} else if steps, err := planEntries(first); err != nil {
+		errors = append(errors, "Plan: first interaction has no valid plan: "+err.Error())
+	} else if len(steps) != 2 {
+		errors = append(errors, fmt.Sprintf("Plan: first interaction has %d steps, expected 2", len(steps)))
+	} else if steps[0]["step"] != "Inspect the plan pipeline" || steps[0]["status"] != "completed" ||
+		steps[1]["step"] != "Verify turn isolation" || steps[1]["status"] != "inProgress" {
+		errors = append(errors, fmt.Sprintf("Plan: first interaction did not persist the latest snapshot: %#v", steps))
+	}
+	if second == nil {
+		errors = append(errors, "Plan: second interaction was not persisted")
+	} else if steps, err := planEntries(second); err != nil {
+		errors = append(errors, "Plan: second interaction has no reset snapshot: "+err.Error())
+	} else if len(steps) != 0 {
+		errors = append(errors, fmt.Sprintf("Plan: second interaction retained %d stale steps", len(steps)))
 	}
 
 	return roundResult{agentName: agent, passed: len(errors) == 0, errors: errors}
@@ -1704,6 +1835,9 @@ func (d *testDriver) validateRound() roundResult {
 	if smokeMode {
 		return d.validateSmokeRound()
 	}
+	if planMode {
+		return d.validatePlanRound()
+	}
 
 	var errors []string
 
@@ -2335,7 +2469,7 @@ func (d *testDriver) validateStore() bool {
 	// Each round creates 5 threads (phases 1, 3, 8, 13, 15) = 5 sessions per round.
 	// Smoke mode runs one phase, so one thread/session per round.
 	perRoundSessions := 5
-	if smokeMode {
+	if smokeMode || planMode {
 		perRoundSessions = 1
 	}
 	expectedSessions := perRoundSessions * len(d.agentRounds)
@@ -2433,7 +2567,7 @@ func (d *testDriver) validateStore() bool {
 					if e.Type == "text" {
 						hasText = true
 					}
-					if e.Type != "text" && e.Type != "tool_call" {
+					if e.Type != "text" && e.Type != "tool_call" && e.Type != "plan" {
 						errors = append(errors, fmt.Sprintf("Interaction %s: unexpected entry type %q",
 							truncate(i.ID, 12), e.Type))
 					}
@@ -2465,6 +2599,8 @@ func (d *testDriver) validateStore() bool {
 	perRoundCompleted := 8
 	if smokeMode {
 		perRoundCompleted = 1
+	} else if planMode {
+		perRoundCompleted = 2
 	}
 	expectedCompleted := perRoundCompleted * len(d.agentRounds)
 	if completedInteractions < expectedCompleted {
@@ -2526,6 +2662,7 @@ func (d *testDriver) validateStore() bool {
 		// Collect message_ids from each interaction
 		type parsedEntry struct {
 			MessageID string `json:"message_id"`
+			Type      string `json:"type"`
 		}
 
 		// For each follow-up interaction, check it doesn't contain message_ids from earlier ones
@@ -2538,7 +2675,10 @@ func (d *testDriver) validateStore() bool {
 
 			// Check for leakage: does this interaction contain message_ids from a previous one?
 			for _, e := range entries {
-				if e.MessageID == "" {
+				// Plan snapshots intentionally use the stable ID "plan" in every
+				// interaction so a new snapshot replaces the old one in place.
+				// Their content, not the ID, is turn-scoped.
+				if e.MessageID == "" || e.Type == "plan" {
 					continue
 				}
 				if ownerID, leaked := previousMessageIDs[e.MessageID]; leaked {
@@ -2550,7 +2690,7 @@ func (d *testDriver) validateStore() bool {
 
 			// Register this interaction's message_ids
 			for _, e := range entries {
-				if e.MessageID != "" {
+				if e.MessageID != "" && e.Type != "plan" {
 					previousMessageIDs[e.MessageID] = inter.ID
 				}
 			}

--- a/crates/external_websocket_sync/e2e-test/plan-test-agent/go.mod
+++ b/crates/external_websocket_sync/e2e-test/plan-test-agent/go.mod
@@ -1,0 +1,3 @@
+module plan-test-agent
+
+go 1.22

--- a/crates/external_websocket_sync/e2e-test/plan-test-agent/go.mod
+++ b/crates/external_websocket_sync/e2e-test/plan-test-agent/go.mod
@@ -1,3 +1,3 @@
 module plan-test-agent
 
-go 1.22
+go 1.25.4

--- a/crates/external_websocket_sync/e2e-test/plan-test-agent/main.go
+++ b/crates/external_websocket_sync/e2e-test/plan-test-agent/main.go
@@ -1,0 +1,146 @@
+// plan-test-agent is a deterministic ACP agent used by the headless Zed E2E
+// suite. Its first turn publishes two plan snapshots; its second turn publishes
+// no plan. This makes plan replacement and turn isolation testable without an
+// external model or nondeterministic prompting.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type request struct {
+	JSONRPC string                 `json:"jsonrpc"`
+	ID      json.RawMessage        `json:"id,omitempty"`
+	Method  string                 `json:"method"`
+	Params  map[string]interface{} `json:"params,omitempty"`
+}
+
+var promptCount int
+
+func write(value interface{}) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[plan-test-agent] marshal: %v\n", err)
+		return
+	}
+	fmt.Fprintln(os.Stdout, string(encoded))
+}
+
+func respond(id json.RawMessage, result interface{}) {
+	write(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"result":  result,
+	})
+}
+
+func notify(sessionID string, update map[string]interface{}) {
+	write(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  "session/update",
+		"params": map[string]interface{}{
+			"sessionId": sessionID,
+			"update":    update,
+		},
+	})
+}
+
+func planEntry(content, status string) map[string]interface{} {
+	return map[string]interface{}{
+		"content":  content,
+		"priority": "medium",
+		"status":   status,
+	}
+}
+
+func publishPlan(sessionID string, entries ...map[string]interface{}) {
+	notify(sessionID, map[string]interface{}{
+		"sessionUpdate": "plan",
+		"entries":       entries,
+	})
+}
+
+func publishText(sessionID, text string) {
+	notify(sessionID, map[string]interface{}{
+		"sessionUpdate": "agent_message_chunk",
+		"content": map[string]interface{}{
+			"type": "text",
+			"text": text,
+		},
+	})
+}
+
+func stringParam(params map[string]interface{}, key, fallback string) string {
+	if value, ok := params[key].(string); ok && value != "" {
+		return value
+	}
+	return fallback
+}
+
+func handle(req request) {
+	switch req.Method {
+	case "initialize":
+		protocolVersion := req.Params["protocolVersion"]
+		if protocolVersion == nil {
+			protocolVersion = 1
+		}
+		respond(req.ID, map[string]interface{}{
+			"protocolVersion":   protocolVersion,
+			"agentCapabilities": map[string]interface{}{},
+			"agentInfo": map[string]interface{}{
+				"name":    "helix-plan-test-agent",
+				"version": "1.0.0",
+			},
+		})
+	case "session/new":
+		respond(req.ID, map[string]interface{}{"sessionId": "plan-test-session"})
+	case "session/prompt":
+		promptCount++
+		sessionID := stringParam(req.Params, "sessionId", "plan-test-session")
+		if promptCount == 1 {
+			publishPlan(sessionID,
+				planEntry("Inspect the plan pipeline", "in_progress"),
+				planEntry("Verify turn isolation", "pending"),
+			)
+			publishPlan(sessionID,
+				planEntry("Inspect the plan pipeline", "completed"),
+				planEntry("Verify turn isolation", "in_progress"),
+			)
+			publishText(sessionID, "First turn complete.")
+		} else {
+			publishText(sessionID, "Second turn has no plan.")
+		}
+		respond(req.ID, map[string]interface{}{"stopReason": "end_turn"})
+	case "session/cancel":
+		// Notifications have no response.
+	default:
+		if len(req.ID) > 0 {
+			write(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      req.ID,
+				"error": map[string]interface{}{
+					"code":    -32601,
+					"message": "method not found",
+				},
+			})
+		}
+	}
+}
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		var req request
+		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+			fmt.Fprintf(os.Stderr, "[plan-test-agent] decode: %v\n", err)
+			continue
+		}
+		handle(req)
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "[plan-test-agent] stdin: %v\n", err)
+	}
+}

--- a/crates/external_websocket_sync/e2e-test/run_docker_e2e.sh
+++ b/crates/external_websocket_sync/e2e-test/run_docker_e2e.sh
@@ -73,6 +73,12 @@ if [ "${1:-}" != "--no-build" ]; then
     CGO_ENABLED=0 go build -o slow-mcp-server .
     echo "Built: $SCRIPT_DIR/slow-mcp-server/slow-mcp-server"
     echo ""
+
+    echo "=== Building deterministic plan test agent ==="
+    cd "$SCRIPT_DIR/plan-test-agent"
+    CGO_ENABLED=0 go build -o plan-test-agent .
+    echo "Built: $SCRIPT_DIR/plan-test-agent/plan-test-agent"
+    echo ""
 fi
 
 # Print binary versions so it's obvious what we're testing
@@ -80,6 +86,7 @@ echo "=== Binary versions ==="
 echo "  zed-binary:          $(stat -c '%y' "$SCRIPT_DIR/zed-binary" 2>/dev/null | cut -d. -f1)  $(md5sum "$SCRIPT_DIR/zed-binary" 2>/dev/null | cut -c1-12)"
 echo "  helix-ws-test-server: $(stat -c '%y' "$SCRIPT_DIR/helix-ws-test-server/helix-ws-test-server" 2>/dev/null | cut -d. -f1)  $(md5sum "$SCRIPT_DIR/helix-ws-test-server/helix-ws-test-server" 2>/dev/null | cut -c1-12)"
 echo "  slow-mcp-server:     $(stat -c '%y' "$SCRIPT_DIR/slow-mcp-server/slow-mcp-server" 2>/dev/null | cut -d. -f1)  $(md5sum "$SCRIPT_DIR/slow-mcp-server/slow-mcp-server" 2>/dev/null | cut -c1-12)"
+echo "  plan-test-agent:     $(stat -c '%y' "$SCRIPT_DIR/plan-test-agent/plan-test-agent" 2>/dev/null | cut -d. -f1)  $(md5sum "$SCRIPT_DIR/plan-test-agent/plan-test-agent" 2>/dev/null | cut -c1-12)"
 echo ""
 
 # Build Docker image

--- a/crates/external_websocket_sync/e2e-test/run_e2e.sh
+++ b/crates/external_websocket_sync/e2e-test/run_e2e.sh
@@ -185,6 +185,7 @@ echo ""
 # reads magic-number.txt and echoes the value. Cheap enough to gate every CI
 # build on. The value is not in the prompt, so it can only come from a tool call.
 export E2E_SMOKE="${E2E_SMOKE:-0}"
+export E2E_PLAN="${E2E_PLAN:-0}"
 if [ "$E2E_SMOKE" = "1" ]; then
     if [ -z "${E2E_SMOKE_FILE:-}" ]; then
         export E2E_SMOKE_FILE="$PROJECT_DIR/magic-number.txt"
@@ -307,6 +308,18 @@ if echo "$E2E_AGENTS" | grep -q "codex"; then
       }
     }"
     echo "[setup] Codex agent configured with API key"
+fi
+
+if echo "$E2E_AGENTS" | grep -q "plan-test-agent"; then
+    if [ -n "$AGENT_SERVER_ENTRIES" ]; then
+        AGENT_SERVER_ENTRIES="${AGENT_SERVER_ENTRIES},"
+    fi
+    AGENT_SERVER_ENTRIES="${AGENT_SERVER_ENTRIES}
+    \"plan-test-agent\": {
+      \"type\": \"custom\",
+      \"command\": \"/usr/local/bin/plan-test-agent\"
+    }"
+    echo "[setup] Deterministic plan test agent configured"
 fi
 
 if [ -n "$AGENT_SERVER_ENTRIES" ]; then


### PR DESCRIPTION
## Summary
- clear the entire ACP plan at each prompt boundary and emit an empty PlanUpdated snapshot
- add a deterministic ACP agent that publishes a plan on turn one and no plan on turn two
- run the lifecycle through headless Zed and Helix production WebSocket handlers without model credentials
- package the test agent in both CI and local E2E images

## Verification
- live headless two-turn E2E: passed
- cargo check -p acp_thread -p external_websocket_sync: passed
- deterministic ACP agent Go build/test: passed
- Helix WebSocket E2E server Go build/test: passed
- shell syntax and git diff checks: passed

## Coordinated Helix PR
https://github.com/helixml/helix/pull/3002