### PR TITLE
Seed synthetic spec task fixture

### DIFF
--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
@@ -1495,6 +1495,7 @@ func (d *testDriver) runPhase11() {
 	// Thread B should be more recently active (Phase 7 completed on it).
 	// Verify routing picks Thread B's session.
 	specTask := &types.SpecTask{ID: specTaskID}
+	d.store.SeedSpecTask(specTask)
 	routedSessionID, err := d.srv.FindConnectedSessionForSpecTask(ctx, specTask)
 	if err != nil {
 		log.Printf("[%s] Phase 11: ERROR FindConnectedSessionForSpecTask failed: %v", agent, err)


### PR DESCRIPTION
## Root cause

Drone build 3599 failed Phase 11 because the E2E fixture assigned a synthetic SpecTaskID to sessions without seeding the matching SpecTask. Current Helix codeAgentConfigSnapshot resolves that ID through GetSpecTask, so the routed SendChatMessage failed with not found and later failures cascaded.

## Fix

Seed the existing synthetic SpecTask in the fixture memory store before routing and sending the Phase 11 message.

## Verification

- git diff --check
- Prime release Zed build at 5f5ca87bac23c4440ab9e38c6e0493e7f7fef53e
- Prime Helix test source at 06f540f10af215d027723d9eb192ef4bee8a911e
- E2E_AGENTS=zed-agent,claude TEST_TIMEOUT=600 ./run_docker_e2e.sh
- Exit 0; all 17 phases passed for both zed-agent and claude

Release Notes:

- N/A