### PR TITLE
test(e2e): add deterministic ACP lifecycle coverage

### DIFF
--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
@@ -74,7 +74,9 @@ type roundState struct {
 	completions map[string][]string // threadID -> list of request_ids
 
 	// Track UI state responses (from query_ui_state)
-	uiStateResponses []types.SyncMessage
+	uiStateResponses       []types.SyncMessage
+	phase7ExpectedThreadID string
+	phase7ChatSent         bool
 
 	// Track timing for MCP tools wait validation
 	phase1ChatSentAt    time.Time // when we sent the chat_message for phase 1
@@ -103,6 +105,8 @@ type roundState struct {
 
 	// Phase 12: reconnect test (kill Zed, reconnect, verify message delivery)
 	phase12Completed bool // whether the reconnected message completed
+	phase12OpenSent  bool
+	phase12ChatSent  bool
 
 	// Phase 13: Helix-initiated cancel via cancel_current_turn
 	phase13ThreadID      string // thread ID for the long-running turn
@@ -154,6 +158,16 @@ type roundState struct {
 type phase15AddSample struct {
 	ts         time.Time
 	contentLen int
+}
+
+type responseEntryKey struct {
+	messageID string
+	content   string
+}
+
+func responseEntryLeak(previous map[responseEntryKey]string, messageID, content string) (string, bool) {
+	owner, leaked := previous[responseEntryKey{messageID: messageID, content: content}]
+	return owner, leaked
 }
 
 func newRoundState(agentName string) *roundState {
@@ -274,6 +288,7 @@ func (d *testDriver) syncEventCallback(sessionID string, syncMsg *types.SyncMess
 
 	switch syncMsg.EventType {
 	case "agent_ready":
+		threadID, _ := syncMsg.Data["thread_id"].(string)
 		if d.phase == 0 {
 			d.phase = 1
 			d.mu.Unlock()
@@ -282,6 +297,38 @@ func (d *testDriver) syncEventCallback(sessionID string, syncMsg *types.SyncMess
 			log.Printf("##################################################")
 			d.stampRoundAgentOnSeedSession(d.round.agentName)
 			d.startRound()
+			return
+		}
+		if d.phase == 7 && !d.round.phase7ChatSent && threadID == d.round.phase7ExpectedThreadID {
+			d.round.phase7ChatSent = true
+			agentName := d.round.agentName
+			requestID := d.round.reqID("phase7")
+			d.mu.Unlock()
+			log.Printf("[%s] Phase 7: open_thread ready for Thread B (%s); sending follow-up", agentName, truncate(threadID, 16))
+			d.sendChatMessage("What is 8 + 8? Reply with just the number.", requestID, agentName, threadID)
+			return
+		}
+		if d.phase == 12 && !d.round.phase12OpenSent {
+			d.round.phase12OpenSent = true
+			agentName := d.round.agentName
+			if len(d.round.threadIDs) == 0 {
+				d.mu.Unlock()
+				log.Printf("[%s] Phase 12: ERROR no thread IDs available", agentName)
+				return
+			}
+			threadID := d.round.threadIDs[0]
+			d.mu.Unlock()
+			log.Printf("[%s] Phase 12: Agent ready after reconnect; opening Thread A (%s)", agentName, truncate(threadID, 16))
+			d.sendOpenThread(threadID, agentName)
+			return
+		}
+		if d.phase == 12 && d.round.phase12OpenSent && !d.round.phase12ChatSent && len(d.round.threadIDs) > 0 && threadID == d.round.threadIDs[0] {
+			d.round.phase12ChatSent = true
+			agentName := d.round.agentName
+			requestID := d.round.reqID("phase12")
+			d.mu.Unlock()
+			log.Printf("[%s] Phase 12: open_thread ready for Thread A (%s); sending follow-up", agentName, truncate(threadID, 16))
+			d.sendChatMessage("What is 12 + 12? Reply with just the number.", requestID, agentName, threadID)
 			return
 		}
 
@@ -586,13 +633,14 @@ func (d *testDriver) syncEventCallback(sessionID string, syncMsg *types.SyncMess
 	case "ui_state_response":
 		d.round.uiStateResponses = append(d.round.uiStateResponses, *syncMsg)
 		currentPhase := d.phase
+		agentName := d.round.agentName
 		queryID, _ := syncMsg.Data["query_id"].(string)
 		activeView, _ := syncMsg.Data["active_view"].(string)
 		threadID, _ := syncMsg.Data["thread_id"].(string)
 		d.mu.Unlock()
 
 		log.Printf("[%s] UI state: query_id=%s active_view=%s thread_id=%s (phase %d)",
-			d.round.agentName, queryID, activeView, truncate(threadID, 12), currentPhase)
+			agentName, queryID, activeView, truncate(threadID, 12), currentPhase)
 
 		if currentPhase == 6 {
 			go d.advanceAfterUiState()
@@ -1287,16 +1335,11 @@ func (d *testDriver) runPhase7() {
 	}
 	// Open Thread B (created in phase 3), then send a follow-up
 	tid := d.round.threadIDs[1]
+	d.round.phase7ExpectedThreadID = tid
 	d.mu.Unlock()
 
 	log.Printf("[%s] Opening Thread B: %s", agent, truncate(tid, 16))
 	d.sendOpenThread(tid, agent)
-
-	// Wait for Zed to open the thread before sending follow-up
-	time.Sleep(3 * time.Second)
-
-	log.Printf("[%s] Sending follow-up to Thread B after open_thread", agent)
-	d.sendChatMessage("What is 8 + 8? Reply with just the number.", d.round.reqID("phase7"), agent, tid)
 }
 
 func (d *testDriver) runPhase8() {
@@ -2328,7 +2371,9 @@ func (d *testDriver) validateRound() roundResult {
 		log.Printf("  [%s] MCP TOOLS WAIT VALIDATION", agent)
 		log.Println("--------------------------------------------------")
 
-		if !d.round.phase1ChatSentAt.IsZero() && !d.round.phase1ThreadCreated.IsZero() {
+		if agent == "lifecycle-test-agent" {
+			log.Printf("[%s] Not applicable: deterministic lifecycle agent has no MCP capability", agent)
+		} else if !d.round.phase1ChatSentAt.IsZero() && !d.round.phase1ThreadCreated.IsZero() {
 			mcpWaitDuration := d.round.phase1ThreadCreated.Sub(d.round.phase1ChatSentAt)
 			log.Printf("[%s] MCP wait: chat_message sent -> thread_created = %s", agent, mcpWaitDuration)
 
@@ -2664,10 +2709,12 @@ func (d *testDriver) validateStore() bool {
 		type parsedEntry struct {
 			MessageID string `json:"message_id"`
 			Type      string `json:"type"`
+			Content   string `json:"content"`
 		}
 
-		// For each follow-up interaction, check it doesn't contain message_ids from earlier ones
-		previousMessageIDs := make(map[string]string) // message_id → interaction_id that owns it
+		// Helix's accumulator identifies an entry by message_id and content.
+		// Agents may reuse a message ID for different content across turns.
+		previousEntries := make(map[responseEntryKey]string)
 		for _, inter := range ints {
 			var entries []parsedEntry
 			if err := json.Unmarshal(inter.ResponseEntries, &entries); err != nil {
@@ -2682,9 +2729,9 @@ func (d *testDriver) validateStore() bool {
 				if e.MessageID == "" || e.Type == "plan" {
 					continue
 				}
-				if ownerID, leaked := previousMessageIDs[e.MessageID]; leaked {
+				if ownerID, leaked := responseEntryLeak(previousEntries, e.MessageID, e.Content); leaked {
 					errors = append(errors, fmt.Sprintf(
-						"ISOLATION VIOLATION: Interaction %s (session %s) contains message_id %q which belongs to earlier interaction %s — response_entries leaked across interactions",
+						"ISOLATION VIOLATION: Interaction %s (session %s) repeats message_id %q with content from earlier interaction %s — response_entries leaked across interactions",
 						truncate(inter.ID, 12), truncate(sessionID, 12), e.MessageID, truncate(ownerID, 12)))
 				}
 			}
@@ -2692,7 +2739,7 @@ func (d *testDriver) validateStore() bool {
 			// Register this interaction's message_ids
 			for _, e := range entries {
 				if e.MessageID != "" && e.Type != "plan" {
-					previousMessageIDs[e.MessageID] = inter.ID
+					previousEntries[responseEntryKey{messageID: e.MessageID, content: e.Content}] = inter.ID
 				}
 			}
 			isolationChecked++
@@ -2846,40 +2893,8 @@ func main() {
 			srv.SetExternalAgentUserMapping(agentID, "e2e-test-user")
 			driver.mu.Lock()
 			driver.agentID = agentID
-			currentPhase := driver.phase
 			driver.mu.Unlock()
-			log.Printf("[test-server] Agent connecting: %s (phase=%d)", agentID, currentPhase)
-
-			// Phase 12: detect reconnection after Zed restart
-			if currentPhase == 12 {
-				go func() {
-					agent := driver.round.agentName
-					log.Printf("[%s] Phase 12: Zed reconnected (new agentID=%s), waiting 5s for initialization...", agent, agentID)
-					time.Sleep(5 * time.Second)
-
-					// Send open_thread first so Zed loads the thread from its DB
-					driver.mu.Lock()
-					if len(driver.round.threadIDs) == 0 {
-						driver.mu.Unlock()
-						log.Printf("[%s] Phase 12: ERROR no thread IDs available", agent)
-						return
-					}
-					threadA := driver.round.threadIDs[0]
-					driver.mu.Unlock()
-
-					log.Printf("[%s] Phase 12: Sending open_thread for Thread A (%s) before chat_message", agent, truncate(threadA, 16))
-					driver.sendOpenThread(threadA, agent)
-
-					// Wait for Zed to load the thread before sending the message.
-					// Thread loading is async — Zed receives open_thread, spawns load task,
-					// connects to agent, loads session from DB. This can take several seconds.
-					time.Sleep(10 * time.Second)
-
-					reqID := driver.round.reqID("phase12")
-					log.Printf("[%s] Phase 12: Sending chat_message to Thread A (%s) with reqID=%s", agent, truncate(threadA, 16), reqID)
-					driver.sendChatMessage("What is 12 + 12? Reply with just the number.", reqID, agent, threadA)
-				}()
-			}
+			log.Printf("[test-server] Agent connecting: %s", agentID)
 		}
 
 		// Delegate to the REAL production handler

--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main_test.go
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main_test.go
@@ -1,0 +1,13 @@
+package main
+
+import "testing"
+
+func TestResponseEntryIsolationKey(t *testing.T) {
+	previous := map[responseEntryKey]string{{messageID: "3", content: "first"}: "interaction-1"}
+	if _, leaked := responseEntryLeak(previous, "3", "second"); leaked {
+		t.Fatal("same message ID with different content must not be treated as leakage")
+	}
+	if owner, leaked := responseEntryLeak(previous, "3", "first"); !leaked || owner != "interaction-1" {
+		t.Fatal("exact message ID and content reuse must be treated as leakage")
+	}
+}

--- a/crates/external_websocket_sync/e2e-test/plan-test-agent/main.go
+++ b/crates/external_websocket_sync/e2e-test/plan-test-agent/main.go
@@ -9,6 +9,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync"
+	"sync/atomic"
+	"time"
 )
 
 type request struct {
@@ -18,7 +21,14 @@ type request struct {
 	Params  map[string]interface{} `json:"params,omitempty"`
 }
 
-var promptCount int
+var (
+	promptCount    int
+	sessionCount   atomic.Int64
+	lifecycleCount atomic.Int64
+	writeMu        sync.Mutex
+	cancelMu       sync.Mutex
+	cancels        = make(map[string]chan struct{})
+)
 
 func write(value interface{}) {
 	encoded, err := json.Marshal(value)
@@ -26,6 +36,8 @@ func write(value interface{}) {
 		fmt.Fprintf(os.Stderr, "[plan-test-agent] marshal: %v\n", err)
 		return
 	}
+	writeMu.Lock()
+	defer writeMu.Unlock()
 	fmt.Fprintln(os.Stdout, string(encoded))
 }
 
@@ -89,15 +101,22 @@ func handle(req request) {
 		}
 		respond(req.ID, map[string]interface{}{
 			"protocolVersion":   protocolVersion,
-			"agentCapabilities": map[string]interface{}{},
+			"agentCapabilities": map[string]interface{}{"loadSession": true},
 			"agentInfo": map[string]interface{}{
 				"name":    "helix-plan-test-agent",
 				"version": "1.0.0",
 			},
 		})
 	case "session/new":
-		respond(req.ID, map[string]interface{}{"sessionId": "plan-test-session"})
+		sessionID := fmt.Sprintf("plan-test-session-%d-%d", os.Getpid(), sessionCount.Add(1))
+		respond(req.ID, map[string]interface{}{"sessionId": sessionID})
+	case "session/load":
+		respond(req.ID, map[string]interface{}{})
 	case "session/prompt":
+		if os.Getenv("E2E_SCRIPTED_LIFECYCLE") == "1" {
+			runLifecyclePrompt(req)
+			return
+		}
 		promptCount++
 		sessionID := stringParam(req.Params, "sessionId", "plan-test-session")
 		if promptCount == 1 {
@@ -115,7 +134,14 @@ func handle(req request) {
 		}
 		respond(req.ID, map[string]interface{}{"stopReason": "end_turn"})
 	case "session/cancel":
-		// Notifications have no response.
+		sessionID := stringParam(req.Params, "sessionId", "")
+		cancelMu.Lock()
+		cancel := cancels[sessionID]
+		delete(cancels, sessionID)
+		cancelMu.Unlock()
+		if cancel != nil {
+			close(cancel)
+		}
 	default:
 		if len(req.ID) > 0 {
 			write(map[string]interface{}{
@@ -128,6 +154,38 @@ func handle(req request) {
 			})
 		}
 	}
+}
+
+func runLifecyclePrompt(req request) {
+	sessionID := stringParam(req.Params, "sessionId", "")
+	turn := lifecycleCount.Add(1)
+	cancel := make(chan struct{})
+	cancelMu.Lock()
+	if previous := cancels[sessionID]; previous != nil {
+		close(previous)
+	}
+	cancels[sessionID] = cancel
+	cancelMu.Unlock()
+
+	go func() {
+		stopReason := "end_turn"
+		for i := 1; i <= 60; i++ {
+			select {
+			case <-cancel:
+				stopReason = "cancelled"
+				i = 60
+			default:
+				publishText(sessionID, fmt.Sprintf("scripted turn %02d chunk %02d. ", turn, i))
+				time.Sleep(120 * time.Millisecond)
+			}
+		}
+		respond(req.ID, map[string]interface{}{"stopReason": stopReason})
+		cancelMu.Lock()
+		if cancels[sessionID] == cancel {
+			delete(cancels, sessionID)
+		}
+		cancelMu.Unlock()
+	}()
 }
 
 func main() {

--- a/crates/external_websocket_sync/e2e-test/run_e2e.sh
+++ b/crates/external_websocket_sync/e2e-test/run_e2e.sh
@@ -252,8 +252,7 @@ if echo "$E2E_AGENTS" | grep -q "claude"; then
         LOCAL_VERSION=$(node -e "console.log(require('/opt/claude-agent-acp/package.json').version)" 2>/dev/null || echo "unknown")
         echo "[setup] Using LOCAL claude-agent-acp v$LOCAL_VERSION from /opt/claude-agent-acp"
     else
-        # Log which version npx will install so we can correlate failures with
-        # claude-agent-acp upgrades. This is a quick check, not an install.
+        # Resolve latest once so the logged version is the version this run executes.
         #
         # The scope matters and has been wrong before: Zed installs
         # @agentclientprotocol/claude-agent-acp (see crates/agent_servers/), NOT
@@ -263,12 +262,11 @@ if echo "$E2E_AGENTS" | grep -q "claude"; then
         CLAUDE_ACP_PKG="@agentclientprotocol/claude-agent-acp"
         CLAUDE_ACP_VERSION=$(npm view "$CLAUDE_ACP_PKG" version 2>/dev/null || echo "")
         if [ -z "$CLAUDE_ACP_VERSION" ]; then
-            echo "[setup] WARNING: could not resolve a version for $CLAUDE_ACP_PKG."
-            echo "[setup]          A claude-round failure will NOT be attributable to an agent-package change."
-            CLAUDE_ACP_VERSION="unknown"
+            echo "[error] Could not resolve $CLAUDE_ACP_PKG@latest"
+            exit 1
         fi
-        echo "[setup] Using npm-installed claude-agent-acp $CLAUDE_ACP_PKG (auto-install, latest=$CLAUDE_ACP_VERSION)"
-        echo "[setup] NOTE: this install is UNPINNED — the claude round is not reproducible across time."
+        CLAUDE_PATH_JSON="\"path\": \"npx\", \"args\": [\"-y\", \"$CLAUDE_ACP_PKG@$CLAUDE_ACP_VERSION\"],"
+        echo "[setup] Latest-provider lane: $CLAUDE_ACP_PKG@$CLAUDE_ACP_VERSION (latest resolved at run start)"
     fi
     AGENT_SERVER_ENTRIES=$(cat << AGENTEOF
     "claude": {
@@ -320,6 +318,19 @@ if echo "$E2E_AGENTS" | grep -q "plan-test-agent"; then
       \"command\": \"/usr/local/bin/plan-test-agent\"
     }"
     echo "[setup] Deterministic plan test agent configured"
+fi
+
+if echo "$E2E_AGENTS" | grep -q "lifecycle-test-agent"; then
+    if [ -n "$AGENT_SERVER_ENTRIES" ]; then
+        AGENT_SERVER_ENTRIES="${AGENT_SERVER_ENTRIES},"
+    fi
+    AGENT_SERVER_ENTRIES="${AGENT_SERVER_ENTRIES}
+    \"lifecycle-test-agent\": {
+      \"type\": \"custom\",
+      \"command\": \"/usr/local/bin/plan-test-agent\",
+      \"env\": { \"E2E_SCRIPTED_LIFECYCLE\": \"1\" }
+    }"
+    echo "[setup] Deterministic lifecycle test agent configured"
 fi
 
 if [ -n "$AGENT_SERVER_ENTRIES" ]; then
@@ -435,7 +446,6 @@ while [ "$ELAPSED" -lt "$TEST_TIMEOUT" ]; do
         rm -f /tmp/zed-restart-requested
         kill "$ZED_PID" 2>/dev/null || true
         wait "$ZED_PID" 2>/dev/null || true
-        sleep 2
         echo "[zed] Restarting Zed..."
         "$ZED_BINARY" \
             --allow-multiple-instances \


### PR DESCRIPTION
## Summary
- validate response isolation by exact message ID and content pairs
- add a deterministic scripted ACP agent for the full lifecycle and race harness
- replace Phase 7 and Phase 12 sleeps with matching agent_ready thread acknowledgements
- keep claude-agent-acp on latest while resolving and logging one exact version per run

## Validation
- focused WebSocket test-server and scripted-agent Go tests/builds passed
- full deterministic lifecycle lane passed all 17 phases headful on Prime
- Helix CI wiring: https://github.com/helixml/helix/pull/3022