### PR TITLE
fix(agent): suppress cancelled queued turns

### DIFF
--- a/crates/external_websocket_sync/PROTOCOL_SPEC.md
+++ b/crates/external_websocket_sync/PROTOCOL_SPEC.md
@@ -207,7 +207,9 @@ Sent when Zed fails to load a thread (e.g., thread is already active in the UI, 
 
 ### `turn_cancelled`
 
-Sent when Zed has processed a `cancel_current_turn` command. Indicates whether the active turn was actually cancelled or there was nothing to cancel.
+Sent when Zed has processed a `cancel_current_turn` command. Indicates whether
+the accepted request was stopped or suppressed before dispatch, or whether Zed
+has never accepted that request ID.
 
 ```json
 {
@@ -222,7 +224,7 @@ Sent when Zed has processed a `cancel_current_turn` command. Indicates whether t
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `request_id` | string | yes | Echoed from the `cancel_current_turn` command |
-| `status` | string | yes | `"cancelled"` if a turn was stopped, `"noop"` if no active turn for that request_id |
+| `status` | string | yes | `"cancelled"` if a running turn was stopped or a queued request was suppressed; `"noop"` if Zed has not accepted that request ID |
 
 ## Helix -> Zed Command Types
 
@@ -270,7 +272,9 @@ Open/focus an existing thread in Zed's UI. This loads the thread from the databa
 
 ### `cancel_current_turn`
 
-Cancel an in-progress AI agent turn. Zed stops the active ACP task for the given `request_id` and replies with a `turn_cancelled` event. If no turn is active for that `request_id`, Zed replies with `turn_cancelled` with `status: "noop"`.
+Cancel an accepted AI agent turn. Zed stops an active ACP task or tombstones a
+request waiting behind another turn, then replies with `status: "cancelled"`.
+Only an unknown or already-completed request ID returns `status: "noop"`.
 
 ```json
 {

--- a/crates/external_websocket_sync/src/external_websocket_sync.rs
+++ b/crates/external_websocket_sync/src/external_websocket_sync.rs
@@ -11,7 +11,7 @@ use tokio::sync::mpsc;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use session::AppSession;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::{Arc, LazyLock}};
 
 mod websocket_sync;
 
@@ -86,6 +86,120 @@ static GLOBAL_UI_STATE_QUERY_CALLBACK: parking_lot::Mutex<Option<mpsc::Unbounded
 /// Static global for cancellation callback (cancels active ACP thread turn by request_id)
 static GLOBAL_CANCELLATION_CALLBACK: parking_lot::Mutex<Option<mpsc::UnboundedSender<CancellationRequest>>> =
     parking_lot::Mutex::new(None);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RequestLifecycle {
+    Queued,
+    Running,
+    Cancelled,
+}
+
+/// Process-level request lifecycle shared by WebSocket ingress, sequential
+/// dispatch, and out-of-band cancellation. This prevents an accepted request
+/// queued behind another turn from running after it was cancelled.
+static REQUEST_LIFECYCLES: LazyLock<parking_lot::Mutex<HashMap<String, RequestLifecycle>>> =
+    LazyLock::new(|| parking_lot::Mutex::new(HashMap::new()));
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CancellationTarget {
+    Queued,
+    Running,
+    AlreadyCancelled,
+    Unknown,
+}
+
+fn register_queued_request(request_id: &str) {
+    REQUEST_LIFECYCLES.lock().entry(request_id.to_string()).or_insert(RequestLifecycle::Queued);
+}
+
+fn cancel_registered_request(request_id: &str) -> CancellationTarget {
+    let mut requests = REQUEST_LIFECYCLES.lock();
+    match requests.get_mut(request_id) {
+        Some(state @ RequestLifecycle::Queued) => {
+            *state = RequestLifecycle::Cancelled;
+            CancellationTarget::Queued
+        }
+        Some(state @ RequestLifecycle::Running) => {
+            *state = RequestLifecycle::Cancelled;
+            CancellationTarget::Running
+        }
+        Some(RequestLifecycle::Cancelled) => CancellationTarget::AlreadyCancelled,
+        None => CancellationTarget::Unknown,
+    }
+}
+
+pub(crate) struct RequestLifecycleGuard(String);
+
+impl RequestLifecycleGuard {
+    pub(crate) fn can_continue(&self) -> bool {
+        matches!(REQUEST_LIFECYCLES.lock().get(&self.0), Some(RequestLifecycle::Running))
+    }
+}
+
+impl Drop for RequestLifecycleGuard {
+    fn drop(&mut self) {
+        REQUEST_LIFECYCLES.lock().remove(&self.0);
+    }
+}
+
+/// Cross queued -> running and invoke `start` under the cancellation mutex.
+/// If cancellation won the race, the closure is never called.
+pub(crate) fn start_registered_request<T>(request_id: &str, start: impl FnOnce() -> T) -> Option<(T, RequestLifecycleGuard)> {
+    let mut requests = REQUEST_LIFECYCLES.lock();
+    match requests.get_mut(request_id) {
+        Some(RequestLifecycle::Cancelled) => {
+            requests.remove(request_id);
+            None
+        }
+        Some(state) => {
+            *state = RequestLifecycle::Running;
+            Some((start(), RequestLifecycleGuard(request_id.to_string())))
+        }
+        None => {
+            // Preserve local/UI callers that bypass WebSocket ingress.
+            requests.insert(request_id.to_string(), RequestLifecycle::Running);
+            Some((start(), RequestLifecycleGuard(request_id.to_string())))
+        }
+    }
+}
+
+pub(crate) fn registered_request_is_cancelled(request_id: &str) -> bool {
+    matches!(REQUEST_LIFECYCLES.lock().get(request_id), Some(RequestLifecycle::Cancelled))
+}
+
+#[cfg(test)]
+mod request_lifecycle_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[test]
+    fn queued_cancellation_suppresses_dispatch() {
+        let request_id = "request-lifecycle-queued-cancel";
+        register_queued_request(request_id);
+        assert_eq!(cancel_registered_request(request_id), CancellationTarget::Queued);
+
+        let started = AtomicBool::new(false);
+        let result = start_registered_request(request_id, || started.store(true, Ordering::SeqCst));
+
+        assert!(result.is_none());
+        assert!(!started.load(Ordering::SeqCst));
+        assert!(!registered_request_is_cancelled(request_id));
+    }
+
+    #[test]
+    fn running_cancellation_stops_retries() {
+        let request_id = "request-lifecycle-running-cancel";
+        register_queued_request(request_id);
+        let (_, guard) = start_registered_request(request_id, || ()).unwrap();
+        assert!(guard.can_continue());
+
+        assert_eq!(cancel_registered_request(request_id), CancellationTarget::Running);
+        assert!(!guard.can_continue());
+        assert!(registered_request_is_cancelled(request_id));
+        drop(guard);
+        assert!(!registered_request_is_cancelled(request_id));
+    }
+}
 
 /// Request to cancel a thread's running turn out-of-band.
 #[derive(Clone, Debug)]
@@ -176,11 +290,14 @@ pub fn request_thread_creation(request: ThreadCreationRequest) -> Result<()> {
     eprintln!("🔧 [CALLBACK] request_thread_creation() called: acp_thread_id={:?}, request_id={}",
                request.acp_thread_id, request.request_id);
 
+    register_queued_request(&request.request_id);
     let sender = GLOBAL_THREAD_CREATION_CALLBACK.lock().clone();
     if let Some(sender) = sender {
         log::info!("✅ [CALLBACK] Found global callback sender, sending request...");
+        let request_id = request.request_id.clone();
         sender.send(request)
             .map_err(|e| {
+                REQUEST_LIFECYCLES.lock().remove(&request_id);
                 log::error!("❌ [CALLBACK] Failed to send to channel: {:?}", e);
                 anyhow::anyhow!("Failed to send thread creation request")
             })?;
@@ -354,11 +471,22 @@ pub fn init_cancellation_callback(sender: mpsc::UnboundedSender<CancellationRequ
     *GLOBAL_CANCELLATION_CALLBACK.lock() = Some(sender);
 }
 
-/// Request cancellation of an active thread turn (called from WebSocket handler)
-/// Unlike thread creation, cancellation requests are not queued — if the handler
-/// isn't ready, we immediately send back a noop turn_cancelled event.
+/// Request cancellation of an accepted thread turn. Queued requests are
+/// tombstoned immediately; running requests go to the out-of-band handler.
 pub fn request_thread_cancellation(request: CancellationRequest) -> Result<()> {
     log::info!("[CALLBACK] request_thread_cancellation() called: request_id={}", request.request_id);
+
+    match cancel_registered_request(&request.request_id) {
+        CancellationTarget::Queued | CancellationTarget::AlreadyCancelled => {
+            log::info!("[CALLBACK] Accepted cancellation before dispatch: request_id={}", request.request_id);
+            send_websocket_event(SyncEvent::TurnCancelled {
+                request_id: request.request_id,
+                status: "cancelled".to_string(),
+            })?;
+            return Ok(());
+        }
+        CancellationTarget::Running | CancellationTarget::Unknown => {}
+    }
 
     let sender = GLOBAL_CANCELLATION_CALLBACK.lock().clone();
     if let Some(sender) = sender {
@@ -601,5 +729,4 @@ pub fn init_cancel_thread_callback(sender: mpsc::UnboundedSender<CancelThreadReq
     log::info!("🔧 [CANCEL] init_cancel_thread_callback() called - registering global callback");
     *GLOBAL_CANCEL_THREAD_CALLBACK.lock() = Some(sender);
 }
-
 

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -1924,22 +1924,34 @@ pub fn setup_thread_handler(
                         task.await;
                         log::info!("[THREAD_SERVICE] Cancelled turn for request_id={}", request.request_id);
                     } else {
-                        log::info!("[THREAD_SERVICE] Thread exists but no turn running for request_id={}, sending noop", request.request_id);
+                        let status = if crate::registered_request_is_cancelled(&request.request_id) {
+                            // Cancellation won between retries or while crossing
+                            // dispatch; the tombstone guarantees no later send.
+                            "cancelled"
+                        } else {
+                            "noop"
+                        };
+                        log::info!("[THREAD_SERVICE] Thread exists but no turn running for request_id={}, sending {}", request.request_id, status);
                         if let Err(e) = crate::send_websocket_event(SyncEvent::TurnCancelled {
                             request_id: request.request_id,
-                            status: "noop".to_string(),
+                            status: status.to_string(),
                         }) {
-                            log::error!("[THREAD_SERVICE] Failed to send turn_cancelled noop event: {}", e);
+                            log::error!("[THREAD_SERVICE] Failed to send turn_cancelled event: {}", e);
                         }
                     }
                 }
                 None => {
-                    log::info!("[THREAD_SERVICE] No active thread for request_id={}, sending noop", request.request_id);
+                    let status = if crate::registered_request_is_cancelled(&request.request_id) {
+                        "cancelled"
+                    } else {
+                        "noop"
+                    };
+                    log::info!("[THREAD_SERVICE] No active thread for request_id={}, sending {}", request.request_id, status);
                     if let Err(e) = crate::send_websocket_event(SyncEvent::TurnCancelled {
                         request_id: request.request_id,
-                        status: "noop".to_string(),
+                        status: status.to_string(),
                     }) {
-                        log::error!("[THREAD_SERVICE] Failed to send turn_cancelled noop event: {}", e);
+                        log::error!("[THREAD_SERVICE] Failed to send turn_cancelled event: {}", e);
                     }
                 }
             }
@@ -2237,15 +2249,20 @@ fn create_new_thread_sync(
 
         // Send the initial message to the thread to trigger AI response
         eprintln!("🔧 [THREAD_SERVICE] About to send message to thread...");
-        let send_task = cx.update(|cx| {
-            thread_entity.update(cx, |thread: &mut AcpThread, cx| {
-                let message = vec![ContentBlock::Text(
-                    TextContent::new(request_clone.message.clone())
-                )];
-                eprintln!("🔧 [THREAD_SERVICE] Calling thread.send() with message: {}", request_clone.message);
-                thread.send(message, cx)
+        let Some((send_task, _request_guard)) = crate::start_registered_request(&request_clone.request_id, || {
+            cx.update(|cx| {
+                thread_entity.update(cx, |thread: &mut AcpThread, cx| {
+                    let message = vec![ContentBlock::Text(
+                        TextContent::new(request_clone.message.clone())
+                    )];
+                    eprintln!("🔧 [THREAD_SERVICE] Calling thread.send() with message: {}", request_clone.message);
+                    thread.send(message, cx)
+                })
             })
-        });
+        }) else {
+            log::info!("[THREAD_SERVICE] Suppressed cancelled request before initial dispatch: {}", request_clone.request_id);
+            return Ok(());
+        };
 
         // Await the send task directly (don't spawn and detach)
         eprintln!("🔧 [THREAD_SERVICE] Awaiting send task...");
@@ -2326,19 +2343,38 @@ async fn handle_follow_up_message(
         thread.update(cx, |thread, _| thread.agent_telemetry_id())
     })?;
     let silence_budget = silent_prompt_wedge_timeout(agent_telemetry_id.as_ref());
+    let mut request_guard = None;
     for attempt in 1..=max_attempts {
         // Snapshot BEFORE dispatch so the watchdog only credits activity that
         // this prompt produced.
         let activity_baseline = activity_count(&thread_id);
 
-        let send_task = cx.update(|cx| {
-            thread.update(cx, |thread: &mut AcpThread, cx| {
-                let message = vec![ContentBlock::Text(
-                    TextContent::new(message.clone())
-                )];
-                thread.send(message, cx)
-            })
-        })?;
+        let send_task = if request_guard.is_none() {
+            let Some((send_task, guard)) = crate::start_registered_request(&request_id, || {
+                cx.update(|cx| {
+                    thread.update(cx, |thread: &mut AcpThread, cx| {
+                        let message = vec![ContentBlock::Text(TextContent::new(message.clone()))];
+                        thread.send(message, cx)
+                    })
+                })
+            }) else {
+                log::info!("[THREAD_SERVICE] Suppressed cancelled follow-up before dispatch: {}", request_id);
+                return Ok(());
+            };
+            request_guard = Some(guard);
+            send_task?
+        } else {
+            if !request_guard.as_ref().unwrap().can_continue() {
+                log::info!("[THREAD_SERVICE] Suppressed cancelled follow-up retry: {}", request_id);
+                return Ok(());
+            }
+            cx.update(|cx| {
+                thread.update(cx, |thread: &mut AcpThread, cx| {
+                    let message = vec![ContentBlock::Text(TextContent::new(message.clone()))];
+                    thread.send(message, cx)
+                })
+            })?
+        };
 
         // Silent-prompt watchdog. Race the turn against a time-to-first-event
         // budget: if the agent produces literally nothing, `send_task` would


### PR DESCRIPTION
## What changed

- track every external WebSocket request as queued, running, or cancelled
- create a cancellation tombstone for accepted queued requests and acknowledge them as cancelled immediately
- transition queued-to-running under the same lock so a cancelled request cannot cross the dispatch boundary
- suppress initial sends, follow-up sends, and ACP retry attempts after cancellation wins the race
- document that `cancelled` covers queued suppression while `noop` is reserved for unknown or completed requests

## Root cause

Zed only tracked the request currently generating on a thread. If Helix cancelled a request that Zed had accepted but queued behind that active request, Zed replied `noop`; the queue then executed the supposedly cancelled request later.

## Impact

Once Zed accepts a request, cancellation is atomic with dispatch. A queued request is either promoted to running or tombstoned, never both.

Companion Helix PR: https://github.com/helixml/helix/pull/3026

## Validation

Passed:

- `cargo check -p external_websocket_sync`
- `cargo test -p external_websocket_sync request_lifecycle_tests --lib` (2/2)
- `git diff --check`

Still running before ready-for-review:

- full Zed release image build
- live API-restart + active/queued cancellation tombstone race
- immediate next turn after cancellation
