### PR TITLE
feat(acp): export context window usage to Helix

### DIFF
--- a/crates/external_websocket_sync/PROTOCOL_SPEC.md
+++ b/crates/external_websocket_sync/PROTOCOL_SPEC.md
@@ -173,7 +173,20 @@ Sent when the AI agent finishes its response for a given request.
   "data": {
     "acp_thread_id": "thread-uuid-here",
     "message_id": "msg-123",
-    "request_id": "req-001"
+    "request_id": "req-001",
+    "agent_name": "codex-acp",
+    "usage": {
+      "total_tokens": 175,
+      "input_tokens": 100,
+      "output_tokens": 75,
+      "thought_tokens": 0,
+      "cached_read_tokens": 40,
+      "cached_write_tokens": 10
+    },
+    "context_usage": {
+      "used_tokens": 120000,
+      "max_tokens": 200000
+    }
   }
 }
 ```
@@ -183,6 +196,9 @@ Sent when the AI agent finishes its response for a given request.
 | `acp_thread_id` | string | yes | Thread the message belongs to |
 | `message_id` | string | yes | The completed message's identifier |
 | `request_id` | string | yes | Echoed from the originating `chat_message` for correlation |
+| `agent_name` | string | yes | ACP agent that completed the turn |
+| `usage` | object | no | Token usage for the completed turn, when reported by the agent |
+| `context_usage` | object | no | Current context-window usage, with `used_tokens` and `max_tokens`, when reported by the agent |
 
 ### `thread_load_error`
 

--- a/crates/external_websocket_sync/src/mock_helix_server.rs
+++ b/crates/external_websocket_sync/src/mock_helix_server.rs
@@ -688,7 +688,7 @@ impl MockHelixServer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{IncomingChatMessage, OutgoingMessage, SyncEvent, TurnUsage};
+    use crate::types::{ContextUsage, IncomingChatMessage, OutgoingMessage, SyncEvent, TurnUsage};
 
     // -----------------------------------------------------------------------
     // Protocol serialization tests
@@ -751,6 +751,10 @@ mod tests {
                 cached_read_tokens: 40,
                 cached_write_tokens: 10,
             }),
+            context_usage: Some(ContextUsage {
+                used_tokens: 120_000,
+                max_tokens: 200_000,
+            }),
         };
 
         let outgoing = event.to_outgoing_message().unwrap();
@@ -761,6 +765,8 @@ mod tests {
         assert_eq!(outgoing.data["agent_name"], "codex-acp");
         assert_eq!(outgoing.data["usage"]["total_tokens"], 175);
         assert_eq!(outgoing.data["usage"]["cached_read_tokens"], 40);
+        assert_eq!(outgoing.data["context_usage"]["used_tokens"], 120_000);
+        assert_eq!(outgoing.data["context_usage"]["max_tokens"], 200_000);
     }
 
     #[test]
@@ -961,6 +967,7 @@ mod tests {
                     request_id: "r2".to_string(),
                     agent_name: "test-agent".to_string(),
                     usage: None,
+                    context_usage: None,
                 },
                 "message_completed",
             ),

--- a/crates/external_websocket_sync/src/protocol_test.rs
+++ b/crates/external_websocket_sync/src/protocol_test.rs
@@ -124,6 +124,7 @@ mod tests {
                     request_id: request.request_id.clone(),
                     agent_name: "test-agent".to_string(),
                     usage: None,
+                    context_usage: None,
                 };
                 zed_to_ext_tx_clone.send(serde_json::to_string(&message_completed).unwrap()).unwrap();
                 println!("📤 Sent message_completed");
@@ -323,6 +324,7 @@ mod tests {
                     request_id: request.request_id.clone(),
                     agent_name: "test-agent".to_string(),
                     usage: None,
+                    context_usage: None,
                 };
                 zed_to_ext_tx_clone.send(serde_json::to_string(&message_completed).unwrap()).unwrap();
                 println!("📤 Sent message_completed");

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -18,7 +18,9 @@ use fs::Fs;
 use project::Project;
 use tokio::sync::mpsc;
 use util::ResultExt;
-use crate::{ExternalAgent, SyncEvent, ThreadCreationRequest, ThreadOpenRequest, TurnUsage};
+use crate::{
+    ContextUsage, ExternalAgent, SyncEvent, ThreadCreationRequest, ThreadOpenRequest, TurnUsage,
+};
 
 fn zed_agent_server_id(agent_name: &str) -> &str {
     match agent_name {
@@ -1286,6 +1288,10 @@ pub fn ensure_thread_subscription(
                                 cached_read_tokens: usage.cached_read_tokens,
                                 cached_write_tokens: usage.cached_write_tokens,
                             }
+                        }),
+                        context_usage: thread.token_usage().map(|usage| ContextUsage {
+                            used_tokens: usage.used_tokens,
+                            max_tokens: usage.max_tokens,
                         }),
                     });
                 }

--- a/crates/external_websocket_sync/src/types.rs
+++ b/crates/external_websocket_sync/src/types.rs
@@ -173,6 +173,12 @@ pub struct TurnUsage {
     pub cached_write_tokens: u64,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ContextUsage {
+    pub used_tokens: u64,
+    pub max_tokens: u64,
+}
+
 /// Events that Zed sends to external system via WebSocket
 /// Per WEBSOCKET_PROTOCOL_SPEC.md - Zed is stateless and only knows about acp_thread_id
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -228,6 +234,8 @@ pub enum SyncEvent {
         agent_name: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         usage: Option<TurnUsage>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        context_usage: Option<ContextUsage>,
     },
     /// Sent when thread loading fails (e.g., session already active via UI)
     #[serde(rename = "thread_load_error")]
@@ -318,7 +326,14 @@ impl SyncEvent {
                     "tool_status": tool_status,
                 })
             ),
-            SyncEvent::MessageCompleted { acp_thread_id, message_id, request_id, agent_name, usage } => (
+            SyncEvent::MessageCompleted {
+                acp_thread_id,
+                message_id,
+                request_id,
+                agent_name,
+                usage,
+                context_usage,
+            } => (
                 "message_completed".to_string(),
                 serde_json::json!({
                     "acp_thread_id": acp_thread_id,
@@ -326,6 +341,7 @@ impl SyncEvent {
                     "request_id": request_id,
                     "agent_name": agent_name,
                     "usage": usage,
+                    "context_usage": context_usage,
                 })
             ),
             SyncEvent::ThreadLoadError { acp_thread_id, request_id, error } => (


### PR DESCRIPTION
## Summary

- include the ACP thread context snapshot in `message_completed` events
- expose `used_tokens` and `max_tokens` independently from per-turn billing usage
- document and test the optional protocol payload

## Testing

- `cargo test -p external_websocket_sync test_sync_event_serialization_roundtrip_message_completed`
- `./stack build-zed release` from the Helix repository
- `./stack build-ubuntu`
- live Zed-backed Helix session exported `19061 / 262144` on the first turn and `19077 / 262144` on the immediately following turn

## Helix PR

https://github.com/helixml/helix/pull/3027