### PR TITLE
feat(sync): report active turns to Helix on agent_ready

### DIFF
--- a/crates/external_websocket_sync/src/external_websocket_sync.rs
+++ b/crates/external_websocket_sync/src/external_websocket_sync.rs
@@ -94,11 +94,63 @@ enum RequestLifecycle {
     Cancelled,
 }
 
+impl RequestLifecycle {
+    /// Wire name reported to Helix in `agent_ready.active_turns`. `Cancelled`
+    /// is never reported: a cancelled turn is one Helix must be free to replace.
+    fn active_turn_state(self) -> Option<&'static str> {
+        match self {
+            RequestLifecycle::Queued => Some("queued"),
+            RequestLifecycle::Running => Some("running"),
+            RequestLifecycle::Cancelled => None,
+        }
+    }
+}
+
+/// One turn this agent already owns, as reported to Helix on reconnect.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ActiveTurn {
+    pub request_id: String,
+    /// The ACP thread the turn belongs to, when ingress named one. Helix
+    /// correlates on `request_id`; this is for diagnosis.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub acp_thread_id: Option<String>,
+    /// "queued" or "running".
+    pub state: String,
+}
+
+/// A turn Helix asked for, tracked from ingress through completion.
+struct TrackedRequest {
+    lifecycle: RequestLifecycle,
+    acp_thread_id: Option<String>,
+}
+
 /// Process-level request lifecycle shared by WebSocket ingress, sequential
 /// dispatch, and out-of-band cancellation. This prevents an accepted request
 /// queued behind another turn from running after it was cancelled.
-static REQUEST_LIFECYCLES: LazyLock<parking_lot::Mutex<HashMap<String, RequestLifecycle>>> =
+///
+/// It is also the source of truth for the `active_turns` report Helix reads on
+/// reconnect. The Zed process outlives a Helix API restart, so this map is what
+/// lets Helix tell "the agent is already running this turn" from "the agent
+/// never received it" — the distinction that stops a reconnect duplicating a
+/// prompt into a live ACP session. See
+/// helix/design/2026-08-16-api-restart-live-turn-reconnect.md.
+static REQUEST_LIFECYCLES: LazyLock<parking_lot::Mutex<HashMap<String, TrackedRequest>>> =
     LazyLock::new(|| parking_lot::Mutex::new(HashMap::new()));
+
+/// Snapshot the turns this agent currently owns, for `agent_ready.active_turns`.
+pub(crate) fn active_turns_snapshot() -> Vec<ActiveTurn> {
+    REQUEST_LIFECYCLES
+        .lock()
+        .iter()
+        .filter_map(|(request_id, tracked)| {
+            tracked.lifecycle.active_turn_state().map(|state| ActiveTurn {
+                request_id: request_id.clone(),
+                acp_thread_id: tracked.acp_thread_id.clone(),
+                state: state.to_string(),
+            })
+        })
+        .collect()
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum CancellationTarget {
@@ -108,22 +160,66 @@ enum CancellationTarget {
     Unknown,
 }
 
-fn register_queued_request(request_id: &str) {
-    REQUEST_LIFECYCLES.lock().entry(request_id.to_string()).or_insert(RequestLifecycle::Queued);
+/// Outcome of admitting a request_id at WebSocket ingress.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RequestAdmission {
+    /// New turn; dispatch it.
+    Accepted,
+    /// This agent is already queued or running this exact turn. Dispatching
+    /// again would send a second prompt into a live ACP session, which the
+    /// agent surfaces as a transport error against the ORIGINAL turn.
+    AlreadyActive,
+}
+
+fn register_queued_request(request_id: &str, acp_thread_id: Option<&str>) -> RequestAdmission {
+    let mut requests = REQUEST_LIFECYCLES.lock();
+    match requests.get_mut(request_id) {
+        Some(tracked) => {
+            // Learn the thread if ingress knows it and we did not.
+            if tracked.acp_thread_id.is_none() {
+                tracked.acp_thread_id = acp_thread_id.map(str::to_string);
+            }
+            match tracked.lifecycle {
+                RequestLifecycle::Queued | RequestLifecycle::Running => {
+                    RequestAdmission::AlreadyActive
+                }
+                // A Cancelled entry is a TOMBSTONE and must be left in place:
+                // `start_registered_request` consumes it to suppress a dispatch
+                // that cancellation already won the race against. Overwriting it
+                // with a fresh Queued would resurrect a turn the user stopped —
+                // which matters because retry paths reuse the interaction id as
+                // the request_id. This mirrors the original `or_insert`, which
+                // was a no-op on an existing key.
+                RequestLifecycle::Cancelled => RequestAdmission::Accepted,
+            }
+        }
+        None => {
+            requests.insert(
+                request_id.to_string(),
+                TrackedRequest {
+                    lifecycle: RequestLifecycle::Queued,
+                    acp_thread_id: acp_thread_id.map(str::to_string),
+                },
+            );
+            RequestAdmission::Accepted
+        }
+    }
 }
 
 fn cancel_registered_request(request_id: &str) -> CancellationTarget {
     let mut requests = REQUEST_LIFECYCLES.lock();
     match requests.get_mut(request_id) {
-        Some(state @ RequestLifecycle::Queued) => {
-            *state = RequestLifecycle::Cancelled;
-            CancellationTarget::Queued
-        }
-        Some(state @ RequestLifecycle::Running) => {
-            *state = RequestLifecycle::Cancelled;
-            CancellationTarget::Running
-        }
-        Some(RequestLifecycle::Cancelled) => CancellationTarget::AlreadyCancelled,
+        Some(tracked) => match tracked.lifecycle {
+            RequestLifecycle::Queued => {
+                tracked.lifecycle = RequestLifecycle::Cancelled;
+                CancellationTarget::Queued
+            }
+            RequestLifecycle::Running => {
+                tracked.lifecycle = RequestLifecycle::Cancelled;
+                CancellationTarget::Running
+            }
+            RequestLifecycle::Cancelled => CancellationTarget::AlreadyCancelled,
+        },
         None => CancellationTarget::Unknown,
     }
 }
@@ -132,7 +228,10 @@ pub(crate) struct RequestLifecycleGuard(String);
 
 impl RequestLifecycleGuard {
     pub(crate) fn can_continue(&self) -> bool {
-        matches!(REQUEST_LIFECYCLES.lock().get(&self.0), Some(RequestLifecycle::Running))
+        matches!(
+            REQUEST_LIFECYCLES.lock().get(&self.0).map(|t| t.lifecycle),
+            Some(RequestLifecycle::Running)
+        )
     }
 }
 
@@ -147,24 +246,30 @@ impl Drop for RequestLifecycleGuard {
 pub(crate) fn start_registered_request<T>(request_id: &str, start: impl FnOnce() -> T) -> Option<(T, RequestLifecycleGuard)> {
     let mut requests = REQUEST_LIFECYCLES.lock();
     match requests.get_mut(request_id) {
-        Some(RequestLifecycle::Cancelled) => {
+        Some(tracked) if tracked.lifecycle == RequestLifecycle::Cancelled => {
             requests.remove(request_id);
             None
         }
-        Some(state) => {
-            *state = RequestLifecycle::Running;
+        Some(tracked) => {
+            tracked.lifecycle = RequestLifecycle::Running;
             Some((start(), RequestLifecycleGuard(request_id.to_string())))
         }
         None => {
             // Preserve local/UI callers that bypass WebSocket ingress.
-            requests.insert(request_id.to_string(), RequestLifecycle::Running);
+            requests.insert(
+                request_id.to_string(),
+                TrackedRequest { lifecycle: RequestLifecycle::Running, acp_thread_id: None },
+            );
             Some((start(), RequestLifecycleGuard(request_id.to_string())))
         }
     }
 }
 
 pub(crate) fn registered_request_is_cancelled(request_id: &str) -> bool {
-    matches!(REQUEST_LIFECYCLES.lock().get(request_id), Some(RequestLifecycle::Cancelled))
+    matches!(
+        REQUEST_LIFECYCLES.lock().get(request_id).map(|t| t.lifecycle),
+        Some(RequestLifecycle::Cancelled)
+    )
 }
 
 #[cfg(test)]
@@ -175,7 +280,7 @@ mod request_lifecycle_tests {
     #[test]
     fn queued_cancellation_suppresses_dispatch() {
         let request_id = "request-lifecycle-queued-cancel";
-        register_queued_request(request_id);
+        register_queued_request(request_id, None);
         assert_eq!(cancel_registered_request(request_id), CancellationTarget::Queued);
 
         let started = AtomicBool::new(false);
@@ -189,7 +294,7 @@ mod request_lifecycle_tests {
     #[test]
     fn running_cancellation_stops_retries() {
         let request_id = "request-lifecycle-running-cancel";
-        register_queued_request(request_id);
+        register_queued_request(request_id, None);
         let (_, guard) = start_registered_request(request_id, || ()).unwrap();
         assert!(guard.can_continue());
 
@@ -198,6 +303,88 @@ mod request_lifecycle_tests {
         assert!(registered_request_is_cancelled(request_id));
         drop(guard);
         assert!(!registered_request_is_cancelled(request_id));
+    }
+
+    #[test]
+    fn duplicate_ingress_is_rejected_while_active() {
+        let request_id = "request-lifecycle-duplicate";
+        assert_eq!(
+            register_queued_request(request_id, Some("thread-a")),
+            RequestAdmission::Accepted
+        );
+        // A Helix reconnect re-sending the same turn must not dispatch twice.
+        assert_eq!(
+            register_queued_request(request_id, Some("thread-a")),
+            RequestAdmission::AlreadyActive
+        );
+
+        let (_, guard) = start_registered_request(request_id, || ()).unwrap();
+        assert_eq!(
+            register_queued_request(request_id, Some("thread-a")),
+            RequestAdmission::AlreadyActive
+        );
+        drop(guard);
+
+        // Once the turn is gone the same id is admissible again (a genuine retry).
+        assert_eq!(
+            register_queued_request(request_id, Some("thread-a")),
+            RequestAdmission::Accepted
+        );
+        REQUEST_LIFECYCLES.lock().remove(request_id);
+    }
+
+    #[test]
+    fn cancelled_tombstone_survives_reingress_and_still_suppresses() {
+        // Cancellation races an in-flight dispatch: the tombstone is what makes
+        // the losing dispatch a no-op. Re-ingress of the same request_id (retry
+        // paths reuse the interaction id) must NOT clear it, or a turn the user
+        // stopped comes back to life.
+        let request_id = "request-lifecycle-tombstone";
+        register_queued_request(request_id, None);
+        assert_eq!(cancel_registered_request(request_id), CancellationTarget::Queued);
+
+        assert_eq!(
+            register_queued_request(request_id, None),
+            RequestAdmission::Accepted,
+            "a cancelled id is admissible at ingress"
+        );
+        assert!(
+            registered_request_is_cancelled(request_id),
+            "but the tombstone must still be there"
+        );
+
+        let started = AtomicBool::new(false);
+        assert!(start_registered_request(request_id, || started.store(true, Ordering::SeqCst)).is_none());
+        assert!(!started.load(Ordering::SeqCst), "the cancelled turn must not dispatch");
+        REQUEST_LIFECYCLES.lock().remove(request_id);
+    }
+
+    #[test]
+    fn active_turns_snapshot_reports_queued_and_running_only() {
+        let queued = "request-lifecycle-snapshot-queued";
+        let running = "request-lifecycle-snapshot-running";
+        let cancelled = "request-lifecycle-snapshot-cancelled";
+        register_queued_request(queued, Some("thread-q"));
+        register_queued_request(running, Some("thread-r"));
+        register_queued_request(cancelled, None);
+        let (_, guard) = start_registered_request(running, || ()).unwrap();
+        cancel_registered_request(cancelled);
+
+        let snapshot = active_turns_snapshot();
+        let find = |id: &str| snapshot.iter().find(|t| t.request_id == id).cloned();
+
+        assert_eq!(find(queued).unwrap().state, "queued");
+        assert_eq!(find(queued).unwrap().acp_thread_id.as_deref(), Some("thread-q"));
+        assert_eq!(find(running).unwrap().state, "running");
+        // A cancelled turn is one Helix must be free to replace, so it is not
+        // reported as owned.
+        assert!(find(cancelled).is_none());
+
+        drop(guard);
+        let mut registry = REQUEST_LIFECYCLES.lock();
+        registry.remove(queued);
+        registry.remove(running);
+        registry.remove(cancelled);
     }
 }
 
@@ -290,7 +477,25 @@ pub fn request_thread_creation(request: ThreadCreationRequest) -> Result<()> {
     eprintln!("🔧 [CALLBACK] request_thread_creation() called: acp_thread_id={:?}, request_id={}",
                request.acp_thread_id, request.request_id);
 
-    register_queued_request(&request.request_id);
+    // Idempotency on request_id. Helix reconnects can re-send a turn this agent
+    // is already running (an old Helix that cannot read active_turns, a racing
+    // retry). Dispatching it again pushes a second prompt into a live ACP
+    // session; the agent rejects it with a transport error carrying the SAME
+    // request_id, which Helix then applies to the original, healthy turn. Drop
+    // the duplicate here so that cannot happen regardless of what Helix decides.
+    if register_queued_request(&request.request_id, request.acp_thread_id.as_deref())
+        == RequestAdmission::AlreadyActive
+    {
+        log::info!(
+            "🔁 [CALLBACK] Ignoring duplicate request_id={} — this turn is already queued or running",
+            request.request_id
+        );
+        eprintln!(
+            "🔁 [CALLBACK] Ignoring duplicate request_id={} — this turn is already queued or running",
+            request.request_id
+        );
+        return Ok(());
+    }
     let sender = GLOBAL_THREAD_CREATION_CALLBACK.lock().clone();
     if let Some(sender) = sender {
         log::info!("✅ [CALLBACK] Found global callback sender, sending request...");

--- a/crates/external_websocket_sync/src/mock_helix_server.rs
+++ b/crates/external_websocket_sync/src/mock_helix_server.rs
@@ -774,12 +774,19 @@ mod tests {
         let event = SyncEvent::AgentReady {
             agent_name: "qwen".to_string(),
             thread_id: Some("thread-existing".to_string()),
+            active_turns: vec![crate::ActiveTurn {
+                request_id: "req-1".to_string(),
+                acp_thread_id: Some("thread-existing".to_string()),
+                state: "running".to_string(),
+            }],
         };
 
         let outgoing = event.to_outgoing_message().unwrap();
         assert_eq!(outgoing.event_type, "agent_ready");
         assert_eq!(outgoing.data["agent_name"], "qwen");
         assert_eq!(outgoing.data["thread_id"], "thread-existing");
+        assert_eq!(outgoing.data["active_turns"][0]["request_id"], "req-1");
+        assert_eq!(outgoing.data["active_turns"][0]["state"], "running");
     }
 
     #[test]
@@ -787,12 +794,16 @@ mod tests {
         let event = SyncEvent::AgentReady {
             agent_name: "zed-agent".to_string(),
             thread_id: None,
+            active_turns: Vec::new(),
         };
 
         let outgoing = event.to_outgoing_message().unwrap();
         assert_eq!(outgoing.event_type, "agent_ready");
         assert_eq!(outgoing.data["agent_name"], "zed-agent");
         assert!(outgoing.data["thread_id"].is_null());
+        // Always serialized, even when empty: Helix distinguishes "reported
+        // nothing running" from "this agent cannot report at all".
+        assert_eq!(outgoing.data["active_turns"].as_array().unwrap().len(), 0);
     }
 
     #[test]
@@ -922,6 +933,7 @@ mod tests {
                 SyncEvent::AgentReady {
                     agent_name: "test".to_string(),
                     thread_id: None,
+                    active_turns: Vec::new(),
                 },
                 "agent_ready",
             ),

--- a/crates/external_websocket_sync/src/types.rs
+++ b/crates/external_websocket_sync/src/types.rs
@@ -260,6 +260,12 @@ pub enum SyncEvent {
         agent_name: String,
         /// Optional thread ID if a thread was loaded from session
         thread_id: Option<String>,
+        /// Turns this agent already owns, from the process-level request
+        /// lifecycle registry. Helix reads this on reconnect to tell "already
+        /// running this turn" from "never received it"; the ABSENCE of the
+        /// field (an agent build predating it) is meaningfully different from
+        /// an empty array, so it is always serialized.
+        active_turns: Vec<crate::ActiveTurn>,
     },
     /// Sent in response to cancel_current_turn command from Helix
     #[serde(rename = "turn_cancelled")]
@@ -359,11 +365,12 @@ impl SyncEvent {
                     "error": error,
                 })
             ),
-            SyncEvent::AgentReady { agent_name, thread_id } => (
+            SyncEvent::AgentReady { agent_name, thread_id, active_turns } => (
                 "agent_ready".to_string(),
                 serde_json::json!({
                     "agent_name": agent_name,
                     "thread_id": thread_id,
+                    "active_turns": active_turns,
                 })
             ),
             SyncEvent::TurnCancelled { request_id, status } => (

--- a/crates/external_websocket_sync/src/websocket_sync.rs
+++ b/crates/external_websocket_sync/src/websocket_sync.rs
@@ -264,14 +264,34 @@ impl WebSocketSync {
             tokio::select! {
                 // Fallback timer: send agent_ready if no open_thread arrived
                 () = &mut agent_ready_timer, if !agent_ready_sent => {
-                    let agent_ready_msg = serde_json::json!({
-                        "event_type": "agent_ready",
-                        "data": {
-                            "agent_name": "zed-connection",
-                            "thread_id": null
+                    // Build this through SyncEvent rather than hand-rolling the
+                    // JSON. Helix reads `active_turns` on every agent_ready to
+                    // decide whether a waiting turn may be re-sent, and treats
+                    // an ABSENT field as "this agent cannot report" — the legacy
+                    // path. A second, hand-built shape on the wire would make a
+                    // current Zed indistinguishable from an old one on exactly
+                    // the connect where no thread was loaded.
+                    //
+                    // The snapshot is meaningful here even with no thread
+                    // loaded: the request registry is process-global, so a turn
+                    // still running from before this connection is reported.
+                    let ready_event = SyncEvent::AgentReady {
+                        agent_name: "zed-connection".to_string(),
+                        thread_id: None,
+                        active_turns: crate::active_turns_snapshot(),
+                    };
+                    let agent_ready_msg = match ready_event
+                        .to_outgoing_message()
+                        .and_then(|m| serde_json::to_string(&m))
+                    {
+                        Ok(json) => json,
+                        Err(e) => {
+                            log::error!("❌ [WEBSOCKET] Failed to serialize timer-based agent_ready: {}", e);
+                            agent_ready_sent = true;
+                            continue;
                         }
-                    });
-                    if let Err(e) = ws_sink.send(Message::Text(agent_ready_msg.to_string().into())).await {
+                    };
+                    if let Err(e) = ws_sink.send(Message::Text(agent_ready_msg.into())).await {
                         eprintln!("⚠️ [WEBSOCKET] Failed to send timer-based agent_ready: {}", e);
                         log::warn!("⚠️ [WEBSOCKET] Failed to send timer-based agent_ready: {}", e);
                     } else {
@@ -695,14 +715,22 @@ pub fn send_websocket_event(event: SyncEvent) -> Result<()> {
 /// This should be called after the agent process (e.g., qwen-code) has initialized via ACP
 /// It prevents race conditions where Helix sends prompts before the agent is ready
 pub fn send_agent_ready(agent_name: String, thread_id: Option<String>) {
-    log::info!("🚀 [WEBSOCKET] Sending agent_ready event: agent_name={}, thread_id={:?}",
-               agent_name, thread_id);
-    eprintln!("🚀 [WEBSOCKET] Sending agent_ready event: agent_name={}, thread_id={:?}",
-              agent_name, thread_id);
+    // Report the turns this agent already owns. A Helix API restart drops the
+    // WebSocket but not this process, so without this report Helix cannot tell a
+    // turn it already handed over from one the agent never received — and
+    // re-sends it into a live ACP session. See
+    // helix/design/2026-08-16-api-restart-live-turn-reconnect.md.
+    let active_turns = crate::active_turns_snapshot();
+
+    log::info!("🚀 [WEBSOCKET] Sending agent_ready event: agent_name={}, thread_id={:?}, active_turns={:?}",
+               agent_name, thread_id, active_turns);
+    eprintln!("🚀 [WEBSOCKET] Sending agent_ready event: agent_name={}, thread_id={:?}, active_turns={:?}",
+              agent_name, thread_id, active_turns);
 
     match send_websocket_event(SyncEvent::AgentReady {
         agent_name: agent_name.clone(),
         thread_id: thread_id.clone(),
+        active_turns,
     }) {
         Ok(_) => {
             log::info!("✅ [WEBSOCKET] agent_ready event sent successfully");


### PR DESCRIPTION
## Why

A Helix API restart drops the sync WebSocket but **not this process** — the turns Zed is running survive it. Helix had no way to ask about them, so on reconnect it could not tell a turn it had already handed over from one this agent never received, and re-sent the prompt into the live ACP session.

The duplicate carries the same `request_id`, so the resulting transport error (`Connection reset by server`) was applied to the original, still-streaming turn and killed it. From that point Helix dropped every remaining chunk as unroutable: a dead chat while the agent kept working. Full RCA: helixml/helix `design/2026-08-16-api-restart-live-turn-reconnect.md`.

`REQUEST_LIFECYCLES` already knew the answer. It just never said it.

## What changed

**Report active turns.** The registry's value becomes a `TrackedRequest` carrying the ACP thread alongside the lifecycle, and `active_turns_snapshot()` renders it as the `active_turns` array on `agent_ready`.

- `Cancelled` turns are deliberately **not** reported — those are turns Helix must be free to replace.
- The field is **always serialized**. An absent field (older build) and an empty array (running nothing) mean opposite things to the reader; conflating them would strand Helix on its compatibility path forever.

**Both emitters carry it.** The 5-second fallback timer in the connection loop hand-rolled its JSON instead of going through `SyncEvent::AgentReady`, so instrumenting only the typed path left it silently missing the field — which would have made a current Zed indistinguishable from an old one on exactly the connect where no thread was loaded. It now builds the same typed event. (Caught by running the E2E, not by any unit test.)

**Idempotent ingress.** `register_queued_request` returns `AlreadyActive` for a request_id already queued or running, and `request_thread_creation` drops it rather than calling `thread.send()` into a busy session. This holds regardless of what Helix decides, so an older Helix is protected too.

A `Cancelled` entry is left in place rather than overwritten — it's a tombstone that `start_registered_request` consumes to suppress a dispatch that cancellation already won the race against, and retry paths reuse the interaction id as the request_id. Getting that wrong would resurrect turns the user had stopped.

## Verification

- 62 crate tests, including `duplicate_ingress_is_rejected_while_active`, `cancelled_tombstone_survives_reingress_and_still_suppresses`, and `active_turns_snapshot_reports_queued_and_running_only`.
- Dockerized E2E, **codex lane 17/17** (`E2E_AGENTS=codex E2E_MODEL_PROVIDER=openai E2E_CODEX_MODEL=gpt-5.6-terra`), with `active_turns` observed on the wire from both emitters — populated while a turn was in flight (`{"request_id":"req-phase1-codex","state":"queued"}`) and empty otherwise. Includes Phase 12 (reconnect), 16 (queue busy-defer) and 17 (queue interrupt).

## Merge order

Helix PR https://github.com/helixml/helix/pull/3049 already pins `ZED_COMMIT=ff59fe7af4b71a3802df68b66294a603d0ff673b`, so it must **not** be merged before this one — otherwise CI points at a commit that isn't on main yet. Merge this first, then the Helix PR.

The Helix side is complete without this change (an agent that cannot report falls into its legacy branch); this only removes the probe delay and makes the decision authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
