### PR TITLE
Finish Agent Questions (ACP Elicitations) — OpenAPI, Tests, E2E and Live Verification

### DIFF
--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
@@ -156,6 +156,7 @@ type roundState struct {
 	// Phase 18: agent questions (ACP elicitations). See runElicitationPhase.
 	phase18Recorded  bool // elicitation_requested produced a live row carrying a non-empty schema
 	phase18Commanded bool // respond_elicitation reached Zed over the wire
+	phase18Acked     bool // Zed's ack round-tripped and reconciled the answered question
 	phase18Resolved  bool // elicitation_resolved(accepted) made the question terminal
 	phase18TurnOK    bool // a normal turn still completes on the same thread afterwards
 }
@@ -1856,10 +1857,23 @@ func (d *testDriver) runQueuePhases() {
 //
 // Consequence worth stating plainly: because the question was injected rather than
 // raised by Zed, the live Zed process does not hold it. When Helix delivers
-// respond_elicitation, Zed correctly answers elicitation_response_ack{not_found}. That
-// ack is the RIGHT answer for an elicitation it never held, so this phase logs it and
-// moves on. It is never a failure condition. What is asserted is that the command
-// reached the wire at all.
+// respond_elicitation, Zed correctly answers elicitation_response_ack{not_found}, and
+// Helix's ack handler then reconciles that question to cancelled(agent_no_longer_holds).
+// That is right — an answer the agent could not apply must stop being offered.
+//
+// It also means one synthetic question cannot test both halves: the ack cancels it, and
+// cancelled is terminal, so a later elicitation_resolved(accepted) correctly affects zero
+// rows. So this phase uses TWO questions:
+//
+//	18a (egress): injected, answered through the production claim-and-send path, then
+//	     asserted to have been reconciled to a terminal state by Zed's real ack. This is
+//	     the round trip — Helix → Zed → Helix — proven end to end.
+//	18b (resolution): injected, then resolved with an injected
+//	     elicitation_resolved(accepted) exactly as a real agent reports it, with no
+//	     command sent, so nothing races the terminal write.
+//
+// Do not "simplify" this back into one question: the merge would silently stop testing
+// one of the two paths.
 func (d *testDriver) runElicitationPhase(sessID, threadID string) {
 	agent := d.round.agentName
 
@@ -1947,49 +1961,86 @@ func (d *testDriver) runElicitationPhase(sessID, threadID string) {
 			agent, len(recorded.Schema))
 	}
 
-	// Answer it through the production claim-then-send path the REST endpoint uses.
+	// --- 18a: egress. Answer through the production claim-then-send path. ---
 	if err := d.srv.RespondToElicitation(ctx, sessID, elicitationID, "accept",
 		map[string]interface{}{"question_0": "redis"}); err != nil {
-		log.Printf("[%s] Phase 18: FAIL — respond_elicitation was not delivered: %v", agent, err)
+		log.Printf("[%s] Phase 18a: FAIL — respond_elicitation was not delivered: %v", agent, err)
 	} else {
 		d.mu.Lock()
 		d.round.phase18Commanded = true
 		d.mu.Unlock()
-		log.Printf("[%s] Phase 18: ✅ respond_elicitation delivered to Zed (expect a not_found ack — see the doc comment)", agent)
+		log.Printf("[%s] Phase 18a: ✅ respond_elicitation delivered to Zed", agent)
 	}
 
-	// Give the real Zed a moment to send its ack back, purely so it lands in the log.
-	time.Sleep(2 * time.Second)
+	// Wait for Zed's real ack to come back and be reconciled. not_found is the correct
+	// ack for a question this Zed never held, and the handler turns it into
+	// cancelled(agent_no_longer_holds) — an answer the agent could not apply must stop
+	// being offered. Asserting the question went terminal proves the whole round trip.
+	acked := false
+	for i := 0; i < 20; i++ {
+		time.Sleep(500 * time.Millisecond)
+		current, err := d.store.GetAgentElicitation(ctx, elicitationID)
+		if err == nil && !current.IsLive() {
+			acked = true
+			log.Printf("[%s] Phase 18a: ✅ Zed's ack round-tripped: question is now %s (%s)",
+				agent, current.Status, current.ResolutionReason)
+			break
+		}
+	}
+	if !acked {
+		log.Printf("[%s] Phase 18a: FAIL — no ack from Zed reconciled the answered question", agent)
+	} else {
+		d.mu.Lock()
+		d.round.phase18Acked = true
+		d.mu.Unlock()
+	}
 	for _, event := range d.filterRoundEvents("elicitation_response_ack") {
 		status, _ := event.Data["status"].(string)
-		log.Printf("[%s] Phase 18: ack from Zed: status=%s (tolerated, not asserted)", agent, status)
+		log.Printf("[%s] Phase 18a: ack event from Zed: status=%s", agent, status)
 	}
 
-	// The agent reports the authoritative terminal status; inject it the same way.
+	// --- 18b: resolution. A fresh question, resolved the way a real agent reports it. ---
+	resolvedID := elicitationID + "-resolved"
+	if err := d.srv.ProcessSyncEvent(sessID, &types.SyncMessage{
+		EventType: "elicitation_requested",
+		Data: map[string]interface{}{
+			"acp_thread_id":    threadID,
+			"elicitation_id":   resolvedID,
+			"entry_index":      "0",
+			"mode":             "form",
+			"message":          "Which cache backend should I use?",
+			"status":           "pending",
+			"requested_schema": requestedSchema,
+		},
+	}); err != nil {
+		log.Printf("[%s] Phase 18b: FAIL — injecting the second elicitation_requested: %v", agent, err)
+		return
+	}
+
 	if err := d.srv.ProcessSyncEvent(sessID, &types.SyncMessage{
 		EventType: "elicitation_resolved",
 		Data: map[string]interface{}{
 			"acp_thread_id":  threadID,
-			"elicitation_id": elicitationID,
+			"elicitation_id": resolvedID,
 			"status":         "accepted",
 		},
 	}); err != nil {
-		log.Printf("[%s] Phase 18: FAIL — injecting elicitation_resolved: %v", agent, err)
+		log.Printf("[%s] Phase 18b: FAIL — injecting elicitation_resolved: %v", agent, err)
 	}
 
-	resolved, err := d.store.GetAgentElicitation(ctx, elicitationID)
+	resolved, err := d.store.GetAgentElicitation(ctx, resolvedID)
 	switch {
 	case err != nil:
-		log.Printf("[%s] Phase 18: FAIL — reloading resolved question: %v", agent, err)
+		log.Printf("[%s] Phase 18b: FAIL — reloading resolved question: %v", agent, err)
 	case resolved.Status != "accepted":
-		log.Printf("[%s] Phase 18: FAIL — question status is %q, wanted accepted", agent, resolved.Status)
+		log.Printf("[%s] Phase 18b: FAIL — question status is %q, wanted accepted", agent, resolved.Status)
 	case resolved.IsLive():
-		log.Printf("[%s] Phase 18: FAIL — question is still answerable after being accepted", agent)
+		log.Printf("[%s] Phase 18b: FAIL — question is still answerable after being accepted", agent)
 	default:
 		d.mu.Lock()
 		d.round.phase18Resolved = true
 		d.mu.Unlock()
-		log.Printf("[%s] Phase 18: ✅ question is terminal (accepted) and no longer answerable", agent)
+		log.Printf("[%s] Phase 18b: ✅ question is terminal (accepted) and no longer answerable", agent)
 	}
 
 	// The elicitation assertions are done; the follow-up turn below has its own explicit
@@ -2589,16 +2640,20 @@ func (d *testDriver) validateRound() roundResult {
 	if !d.round.phase17Delivered {
 		errors = append(errors, "Phase 17: interrupt queue message was never delivered")
 	}
-	// Phase 18: agent questions (ACP elicitations). The ack Zed returns is deliberately
-	// not validated here — see runElicitationPhase for why a not_found is correct.
+	// Phase 18: agent questions (ACP elicitations). 18a proves the Helix → Zed → Helix
+	// round trip; 18b proves the resolution path. See runElicitationPhase for why these
+	// need two separate questions.
 	if !d.round.phase18Recorded {
 		errors = append(errors, "Phase 18: the question was not recorded live with a populated schema")
 	}
 	if !d.round.phase18Commanded {
-		errors = append(errors, "Phase 18: respond_elicitation was never delivered to the agent")
+		errors = append(errors, "Phase 18a: respond_elicitation was never delivered to the agent")
+	}
+	if !d.round.phase18Acked {
+		errors = append(errors, "Phase 18a: Zed's ack never round-tripped to reconcile the answered question")
 	}
 	if !d.round.phase18Resolved {
-		errors = append(errors, "Phase 18: the question did not become terminal after being accepted")
+		errors = append(errors, "Phase 18b: the question did not become terminal after being accepted")
 	}
 	if !d.round.phase18TurnOK {
 		errors = append(errors, "Phase 18: no normal turn completed after the question cycle (thread wedged)")

--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
@@ -4,7 +4,7 @@
 // tests and production.
 //
 // The server runs multiple "rounds", one per agent type (zed-agent, claude, etc.).
-// Each round executes the same 15 test phases:
+// Each round executes the same 18 test phases:
 //
 //	Phase 1: Basic thread creation (new chat_message, no thread ID)
 //	Phase 2: Follow-up on existing thread (same thread ID)
@@ -24,6 +24,12 @@
 //	          arrive throughout the response, not bunched at the end. Catches the regression where Zed's
 //	          streaming-reveal task drains text into the markdown entity without re-emitting EntryUpdated,
 //	          so external_websocket_sync only sees stale snapshots until message_completed.)
+//	Phase 16: Queue busy-defer (enqueue interrupt=false while busy — assert it is HELD, then delivered once idle)
+//	Phase 17: Queue interrupt (enqueue interrupt=true while busy — assert it cancels the running turn and delivers)
+//	Phase 18: Agent question / ACP elicitation (inject elicitation_requested with a non-empty schema →
+//	          respond_elicitation over the wire → elicitation_resolved(accepted) → a normal turn still
+//	          completes. Synthetic by design: a real question depends on the model choosing to call
+//	          AskUserQuestion, which no prompt reliably forces. See runElicitationPhase.)
 //
 // Smoke mode (E2E_SMOKE=1) replaces the phase chain above with a single phase:
 // the agent is asked to read a file holding a magic number and echo it back. It
@@ -146,6 +152,12 @@ type roundState struct {
 	phase16Delivered   bool   // the deferred message was delivered as the next turn once idle
 	phase17Interrupted bool   // interrupt=true cancelled the running turn (interaction went interrupted)
 	phase17Delivered   bool   // the interrupt message was delivered
+
+	// Phase 18: agent questions (ACP elicitations). See runElicitationPhase.
+	phase18Recorded  bool // elicitation_requested produced a live row carrying a non-empty schema
+	phase18Commanded bool // respond_elicitation reached Zed over the wire
+	phase18Resolved  bool // elicitation_resolved(accepted) made the question terminal
+	phase18TurnOK    bool // a normal turn still completes on the same thread afterwards
 }
 
 // phase15AddSample records a single message_added event tied to phase 15's
@@ -1476,6 +1488,13 @@ func (d *testDriver) runPhase11() {
 		return
 	}
 
+	// The SpecTask row must exist before any session points at it. Production
+	// resolves the code-agent configuration for every chat message
+	// (codeAgentConfigSnapshot), and that lookup is a hard error when the task is
+	// missing — a session carrying a SpecTaskID whose row does not exist is a state
+	// production never reaches, so failing there is correct and seeding here is the fix.
+	d.store.SeedSpecTask(&types.SpecTask{ID: specTaskID})
+
 	// Set SpecTaskID on both sessions
 	for _, sid := range []string{sessionA, sessionB} {
 		ses, err := d.store.GetSession(ctx, sid)
@@ -1817,7 +1836,182 @@ func (d *testDriver) runQueuePhases() {
 		log.Printf("[%s] Phase 17: FAIL — interrupt message never delivered", agent)
 	}
 
+	d.runElicitationPhase(sessID, threadID)
+
 	d.advanceToNextRound()
+}
+
+// runElicitationPhase drives Phase 18: an agent question (ACP elicitation) is recorded,
+// answered, resolved, and the turn keeps working afterwards.
+//
+// WHY THIS IS SYNTHETIC — do not "fix" it into a model-driven phase.
+//
+// A real elicitation originates from Claude Code choosing to call its built-in
+// AskUserQuestion tool. That is a model-behaviour coin flip: no prompt reliably forces
+// it, and a CI phase that waits for one is flaky by construction. So the question is
+// injected through the same seam Phase 10 uses for user_created_thread — the event is
+// fabricated and handed to the REAL production handler via ProcessSyncEvent. Everything
+// downstream of that injection is production code: the row, the transcript entry, the
+// conditional status transitions, and the command egress to the live Zed.
+//
+// Consequence worth stating plainly: because the question was injected rather than
+// raised by Zed, the live Zed process does not hold it. When Helix delivers
+// respond_elicitation, Zed correctly answers elicitation_response_ack{not_found}. That
+// ack is the RIGHT answer for an elicitation it never held, so this phase logs it and
+// moves on. It is never a failure condition. What is asserted is that the command
+// reached the wire at all.
+func (d *testDriver) runElicitationPhase(sessID, threadID string) {
+	agent := d.round.agentName
+
+	d.mu.Lock()
+	d.phase = 18
+	d.mu.Unlock()
+	log.Printf("\n==================================================")
+	log.Printf("  [%s] PHASE 18: Agent question (ACP elicitation)", agent)
+	log.Printf("==================================================")
+	d.startPhaseTimeout(18)
+
+	ctx := context.Background()
+	elicitationID := fmt.Sprintf("elicit-e2e-%s-%d", agent, time.Now().UnixNano())
+
+	// A schema shaped like the real adapter's: a question with two labelled options plus
+	// the sibling free-text field. Asserting it survives the round trip non-empty guards
+	// the failure this whole feature exists to prevent — a question reaching the user
+	// with no options to pick.
+	requestedSchema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"question_0": map[string]interface{}{
+				"type":        "string",
+				"title":       "Which cache backend should I use?",
+				"description": "Pick one",
+				"oneOf": []interface{}{
+					map[string]interface{}{"const": "redis", "title": "Redis"},
+					map[string]interface{}{"const": "memcached", "title": "Memcached"},
+				},
+			},
+			"question_0_custom": map[string]interface{}{
+				"type":  "string",
+				"title": "Other",
+				"_meta": map[string]interface{}{
+					"_askUserQuestionCustomAnswer": map[string]interface{}{
+						"isCustomAnswer": true,
+						"questionId":     "question_0",
+					},
+				},
+			},
+		},
+	}
+
+	if err := d.srv.ProcessSyncEvent(sessID, &types.SyncMessage{
+		EventType: "elicitation_requested",
+		Data: map[string]interface{}{
+			"acp_thread_id":    threadID,
+			"elicitation_id":   elicitationID,
+			"entry_index":      "0",
+			"mode":             "form",
+			"message":          "Which cache backend should I use?",
+			"status":           "pending",
+			"requested_schema": requestedSchema,
+		},
+	}); err != nil {
+		log.Printf("[%s] Phase 18: FAIL — injecting elicitation_requested: %v", agent, err)
+		return
+	}
+
+	// The row must exist, be answerable, and still carry the schema.
+	live, err := d.store.ListLiveAgentElicitationsForSession(ctx, sessID)
+	if err != nil {
+		log.Printf("[%s] Phase 18: FAIL — listing live questions: %v", agent, err)
+		return
+	}
+	var recorded *types.AgentElicitation
+	for _, elicitation := range live {
+		if elicitation.ID == elicitationID {
+			recorded = elicitation
+			break
+		}
+	}
+	switch {
+	case recorded == nil:
+		log.Printf("[%s] Phase 18: FAIL — question was not recorded as live on session %s", agent, sessID)
+	case len(recorded.Schema) == 0:
+		log.Printf("[%s] Phase 18: FAIL — question recorded with an EMPTY schema (the user would see no options)", agent)
+	case !strings.Contains(string(recorded.Schema), "memcached"):
+		log.Printf("[%s] Phase 18: FAIL — schema lost its options in transit: %s", agent, string(recorded.Schema))
+	default:
+		d.mu.Lock()
+		d.round.phase18Recorded = true
+		d.mu.Unlock()
+		log.Printf("[%s] Phase 18: ✅ question recorded pending with a %d-byte schema carrying both options",
+			agent, len(recorded.Schema))
+	}
+
+	// Answer it through the production claim-then-send path the REST endpoint uses.
+	if err := d.srv.RespondToElicitation(ctx, sessID, elicitationID, "accept",
+		map[string]interface{}{"question_0": "redis"}); err != nil {
+		log.Printf("[%s] Phase 18: FAIL — respond_elicitation was not delivered: %v", agent, err)
+	} else {
+		d.mu.Lock()
+		d.round.phase18Commanded = true
+		d.mu.Unlock()
+		log.Printf("[%s] Phase 18: ✅ respond_elicitation delivered to Zed (expect a not_found ack — see the doc comment)", agent)
+	}
+
+	// Give the real Zed a moment to send its ack back, purely so it lands in the log.
+	time.Sleep(2 * time.Second)
+	for _, event := range d.filterRoundEvents("elicitation_response_ack") {
+		status, _ := event.Data["status"].(string)
+		log.Printf("[%s] Phase 18: ack from Zed: status=%s (tolerated, not asserted)", agent, status)
+	}
+
+	// The agent reports the authoritative terminal status; inject it the same way.
+	if err := d.srv.ProcessSyncEvent(sessID, &types.SyncMessage{
+		EventType: "elicitation_resolved",
+		Data: map[string]interface{}{
+			"acp_thread_id":  threadID,
+			"elicitation_id": elicitationID,
+			"status":         "accepted",
+		},
+	}); err != nil {
+		log.Printf("[%s] Phase 18: FAIL — injecting elicitation_resolved: %v", agent, err)
+	}
+
+	resolved, err := d.store.GetAgentElicitation(ctx, elicitationID)
+	switch {
+	case err != nil:
+		log.Printf("[%s] Phase 18: FAIL — reloading resolved question: %v", agent, err)
+	case resolved.Status != "accepted":
+		log.Printf("[%s] Phase 18: FAIL — question status is %q, wanted accepted", agent, resolved.Status)
+	case resolved.IsLive():
+		log.Printf("[%s] Phase 18: FAIL — question is still answerable after being accepted", agent)
+	default:
+		d.mu.Lock()
+		d.round.phase18Resolved = true
+		d.mu.Unlock()
+		log.Printf("[%s] Phase 18: ✅ question is terminal (accepted) and no longer answerable", agent)
+	}
+
+	// The elicitation assertions are done; the follow-up turn below has its own explicit
+	// deadline and is reported as a validation failure, not an abort. Release the phase
+	// watchdog first, or its 90s timer races that wait and os.Exit(1)s a passing phase.
+	d.markPhaseSucceeded(18)
+
+	// Test the NEXT operation, not just the state change: a normal turn must still
+	// complete on this thread once the question cycle is done.
+	promptZ, err := d.srv.EnqueueQueuedPrompt(sessID, "Reply with exactly this one sentence: The cache is warm.", false)
+	if err != nil {
+		log.Printf("[%s] Phase 18: FAIL — enqueue after question failed: %v", agent, err)
+		return
+	}
+	if d.waitInteractionState(promptZ, map[string]bool{"complete": true}, 90*time.Second) {
+		d.mu.Lock()
+		d.round.phase18TurnOK = true
+		d.mu.Unlock()
+		log.Printf("[%s] Phase 18: ✅ a normal turn still completes after the question cycle", agent)
+	} else {
+		log.Printf("[%s] Phase 18: FAIL — the thread is wedged: no turn completed after the question", agent)
+	}
 }
 
 // --- Per-round validation ---
@@ -2394,6 +2588,20 @@ func (d *testDriver) validateRound() roundResult {
 	}
 	if !d.round.phase17Delivered {
 		errors = append(errors, "Phase 17: interrupt queue message was never delivered")
+	}
+	// Phase 18: agent questions (ACP elicitations). The ack Zed returns is deliberately
+	// not validated here — see runElicitationPhase for why a not_found is correct.
+	if !d.round.phase18Recorded {
+		errors = append(errors, "Phase 18: the question was not recorded live with a populated schema")
+	}
+	if !d.round.phase18Commanded {
+		errors = append(errors, "Phase 18: respond_elicitation was never delivered to the agent")
+	}
+	if !d.round.phase18Resolved {
+		errors = append(errors, "Phase 18: the question did not become terminal after being accepted")
+	}
+	if !d.round.phase18TurnOK {
+		errors = append(errors, "Phase 18: no normal turn completed after the question cycle (thread wedged)")
 	}
 
 	// --- SUMMARY ---

--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
@@ -1887,6 +1887,10 @@ func (d *testDriver) runElicitationPhase(sessID, threadID string) {
 
 	ctx := context.Background()
 	elicitationID := fmt.Sprintf("elicit-e2e-%s-%d", agent, time.Now().UnixNano())
+	// Real Zed stamps elicitation events with the turn-scoped request_id. Sending one
+	// keeps this phase on the mapped-request path rather than the empty-request_id
+	// fallback, which is a different code path with its own test coverage.
+	requestID := fmt.Sprintf("req-phase18-%s", agent)
 
 	// A schema shaped like the real adapter's: a question with two labelled options plus
 	// the sibling free-text field. Asserting it survives the round trip non-empty guards
@@ -1922,6 +1926,7 @@ func (d *testDriver) runElicitationPhase(sessID, threadID string) {
 		Data: map[string]interface{}{
 			"acp_thread_id":    threadID,
 			"elicitation_id":   elicitationID,
+			"request_id":       requestID,
 			"entry_index":      "0",
 			"mode":             "form",
 			"message":          "Which cache backend should I use?",
@@ -2006,6 +2011,7 @@ func (d *testDriver) runElicitationPhase(sessID, threadID string) {
 		Data: map[string]interface{}{
 			"acp_thread_id":    threadID,
 			"elicitation_id":   resolvedID,
+			"request_id":       requestID,
 			"entry_index":      "0",
 			"mode":             "form",
 			"message":          "Which cache backend should I use?",
@@ -2830,7 +2836,10 @@ func (d *testDriver) validateStore() bool {
 					if e.Type == "text" {
 						hasText = true
 					}
-					if e.Type != "text" && e.Type != "tool_call" && e.Type != "plan" {
+					// "elicitation" is a question the agent asked the user; it lives
+					// inline in the transcript so it renders in conversation order and
+					// stays there once answered (Phase 18).
+					if e.Type != "text" && e.Type != "tool_call" && e.Type != "plan" && e.Type != "elicitation" {
 						errors = append(errors, fmt.Sprintf("Interaction %s: unexpected entry type %q",
 							truncate(i.ID, 12), e.Type))
 					}

--- a/crates/external_websocket_sync/e2e-test/run_e2e.sh
+++ b/crates/external_websocket_sync/e2e-test/run_e2e.sh
@@ -20,10 +20,12 @@ echo "============================================"
 echo ""
 
 ZED_BINARY="${ZED_BINARY:-/usr/local/bin/zed}"
-# Default timeout scales with number of agent rounds (each round takes ~150s
-# including Phase 15's long-form prose streaming).
+# Default timeout scales with number of agent rounds. A zed-agent round measured
+# ~190s once Phase 18 (agent questions) was added, and the claude round is slower
+# still, so 300s/round no longer leaves headroom — a two-agent run was timing out
+# mid-round-2 with every phase passing.
 AGENT_COUNT=$(echo "${E2E_AGENTS:-zed-agent}" | tr ',' '\n' | wc -l)
-DEFAULT_TIMEOUT=$((300 * AGENT_COUNT))
+DEFAULT_TIMEOUT=$((450 * AGENT_COUNT))
 TEST_TIMEOUT="${TEST_TIMEOUT:-$DEFAULT_TIMEOUT}"
 MOCK_SERVER="${HELIX_WS_TEST_SERVER:-/usr/local/bin/helix-ws-test-server}"
 PROJECT_DIR="/test/project"

--- a/crates/external_websocket_sync/src/external_websocket_sync.rs
+++ b/crates/external_websocket_sync/src/external_websocket_sync.rs
@@ -116,6 +116,30 @@ static GLOBAL_CANCEL_THREAD_CALLBACK: parking_lot::Mutex<Option<mpsc::UnboundedS
 static PENDING_UI_STATE_QUERIES: parking_lot::Mutex<Vec<UiStateQueryRequest>> =
     parking_lot::Mutex::new(Vec::new());
 
+/// A user's answer to a pending elicitation, arriving from Helix.
+#[derive(Clone, Debug)]
+pub struct ElicitationResponseRequest {
+    pub acp_thread_id: String,
+    pub elicitation_id: String,
+    /// "accept" | "decline". "cancel" is reserved for teardown, never sent by a user.
+    pub action: String,
+    /// Field name → answer, straight from the form the user filled in.
+    pub content: Option<serde_json::Value>,
+}
+
+/// Static global for the elicitation-response callback.
+/// Answering runs on its own GPUI task for the same reason cancelling does: the
+/// sequential creation loop is blocked awaiting the very turn that is waiting on this
+/// answer, so delivering through it would deadlock.
+static GLOBAL_ELICITATION_RESPONSE_CALLBACK: parking_lot::Mutex<
+    Option<mpsc::UnboundedSender<ElicitationResponseRequest>>,
+> = parking_lot::Mutex::new(None);
+
+/// Static global for requesting a full elicitation resync (on WebSocket reconnect).
+static GLOBAL_ELICITATION_RESYNC_CALLBACK: parking_lot::Mutex<
+    Option<mpsc::UnboundedSender<()>>,
+> = parking_lot::Mutex::new(None);
+
 /// Request to create ACP thread from external WebSocket message
 #[derive(Clone, Debug)]
 pub struct ThreadCreationRequest {
@@ -600,6 +624,63 @@ pub fn init_cancel_thread_callback(sender: mpsc::UnboundedSender<CancelThreadReq
     eprintln!("🔧 [CANCEL] init_cancel_thread_callback() called - registering global callback");
     log::info!("🔧 [CANCEL] init_cancel_thread_callback() called - registering global callback");
     *GLOBAL_CANCEL_THREAD_CALLBACK.lock() = Some(sender);
+}
+
+/// Deliver a user's answer to a pending elicitation, unblocking the agent's turn.
+pub fn request_elicitation_response(request: ElicitationResponseRequest) -> Result<()> {
+    log::info!(
+        "[ELICITATION] Answer for {} on thread {} (action={})",
+        request.elicitation_id,
+        request.acp_thread_id,
+        request.action
+    );
+
+    let sender = GLOBAL_ELICITATION_RESPONSE_CALLBACK.lock().clone();
+    let Some(sender) = sender else {
+        // No task to deliver to means no thread is loaded, so there is nothing to
+        // answer. Tell Helix rather than dropping it silently — a swallowed answer
+        // leaves the user staring at a question that never resolves.
+        log::warn!(
+            "[ELICITATION] Response callback not initialized; cannot answer {}",
+            request.elicitation_id
+        );
+        if let Err(e) = send_websocket_event(SyncEvent::ElicitationResponseAck {
+            elicitation_id: request.elicitation_id,
+            status: "not_found".to_string(),
+            error: "no thread service running".to_string(),
+        }) {
+            log::warn!("[ELICITATION] Failed to send not_found ack: {}", e);
+        }
+        return Ok(());
+    };
+
+    sender
+        .send(request)
+        .map_err(|_| anyhow::anyhow!("Failed to send elicitation response"))
+}
+
+/// Initialize the global elicitation-response callback (called from thread_service).
+pub fn init_elicitation_response_callback(
+    sender: mpsc::UnboundedSender<ElicitationResponseRequest>,
+) {
+    log::info!("[ELICITATION] Registering elicitation response callback");
+    *GLOBAL_ELICITATION_RESPONSE_CALLBACK.lock() = Some(sender);
+}
+
+/// Ask the heartbeat task to re-announce outstanding questions in full. Called when the
+/// WebSocket reconnects, because the Helix on the other end may have restarted and lost
+/// track of what is pending.
+pub fn request_elicitation_resync() {
+    if let Some(sender) = GLOBAL_ELICITATION_RESYNC_CALLBACK.lock().clone() {
+        if sender.send(()).is_err() {
+            log::warn!("[ELICITATION] Resync channel closed");
+        }
+    }
+}
+
+/// Initialize the global elicitation-resync callback (called from thread_service).
+pub fn init_elicitation_resync_callback(sender: mpsc::UnboundedSender<()>) {
+    *GLOBAL_ELICITATION_RESYNC_CALLBACK.lock() = Some(sender);
 }
 
 

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -1821,15 +1821,12 @@ pub fn setup_thread_handler(
                 announce_full = true;
             }
 
-            match cx.update(|cx| resync_all_elicitations(cx, announce_full)) {
-                Ok(count) if count > 0 => {
-                    log::info!("[ELICITATION] Heartbeat: {} question(s) outstanding", count);
-                }
-                Ok(_) => {}
-                Err(e) => {
-                    log::warn!("[ELICITATION] Heartbeat stopping: {}", e);
-                    return;
-                }
+            // `AsyncApp::update` returns the closure's value directly — it does not wrap
+            // it in a Result — so there is no teardown error to observe here. The task is
+            // detached and simply stops with the app.
+            let count = cx.update(|cx| resync_all_elicitations(cx, announce_full));
+            if count > 0 {
+                log::info!("[ELICITATION] Heartbeat: {} question(s) outstanding", count);
             }
         }
     })
@@ -1895,8 +1892,11 @@ pub fn setup_thread_handler(
                 })
             });
 
+            // `AsyncApp::update` is infallible and returns the closure's value directly;
+            // the only Result here is the entity update, which fails if the thread was
+            // dropped between the lookup above and this call.
             match result {
-                Ok(Ok(status)) => {
+                Ok(status) => {
                     log::info!(
                         "[ELICITATION] Answer for {} → {}",
                         request.elicitation_id,
@@ -1909,7 +1909,7 @@ pub fn setup_thread_handler(
                     };
                     send_elicitation_ack(&request.elicitation_id, status, error);
                 }
-                Ok(Err(e)) | Err(e) => {
+                Err(e) => {
                     log::warn!(
                         "[ELICITATION] Failed to answer {}: {}",
                         request.elicitation_id,

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -609,6 +609,249 @@ async fn trailing_flush_timer(key: String) {
     }
 }
 
+/// The `toolCallId` the agent attached to an elicitation, if any. It rides on the
+/// request's scope rather than on the request itself.
+fn elicitation_tool_call_id(request: &acp::CreateElicitationRequest) -> String {
+    match request.scope() {
+        acp::ElicitationScope::Session(scope) => scope
+            .tool_call_id
+            .as_ref()
+            .map(|id| id.0.to_string())
+            .unwrap_or_default(),
+        _ => String::new(),
+    }
+}
+
+/// Mode name plus the `requestedSchema` as verbatim JSON. The schema is passed straight
+/// through because Helix renders the question from it — flattening here would silently
+/// drop options and descriptions the agent offered.
+fn elicitation_mode_and_schema(
+    request: &acp::CreateElicitationRequest,
+) -> (String, serde_json::Value) {
+    match &request.mode {
+        acp::ElicitationMode::Form(mode) => (
+            "form".to_string(),
+            serde_json::to_value(&mode.requested_schema).unwrap_or(serde_json::Value::Null),
+        ),
+        acp::ElicitationMode::Url(mode) => (
+            "url".to_string(),
+            serde_json::json!({ "url": mode.url }),
+        ),
+        _ => ("other".to_string(), serde_json::Value::Null),
+    }
+}
+
+/// Announce a question to Helix. Safe to call repeatedly for the same elicitation —
+/// the Go side upserts by id, which is what makes the reconnect resync cheap.
+fn send_elicitation_requested(
+    thread: &AcpThread,
+    acp_thread_id: &str,
+    request_id: &str,
+    elicitation_id: &acp_thread::ElicitationEntryId,
+) {
+    let Some((entry_index, elicitation)) = thread.elicitation(elicitation_id) else {
+        log::warn!(
+            "[ELICITATION] Requested event for unknown elicitation {} on thread {}",
+            elicitation_id.0,
+            acp_thread_id
+        );
+        return;
+    };
+    let (mode, requested_schema) = elicitation_mode_and_schema(&elicitation.request);
+    log::info!(
+        "[ELICITATION] Question on thread {} entry {} id {} ({})",
+        acp_thread_id,
+        entry_index,
+        elicitation_id.0,
+        mode
+    );
+    crate::send_websocket_event(SyncEvent::ElicitationRequested {
+        acp_thread_id: acp_thread_id.to_string(),
+        request_id: request_id.to_string(),
+        entry_index: entry_index.to_string(),
+        elicitation_id: elicitation_id.0.to_string(),
+        tool_call_id: elicitation_tool_call_id(&elicitation.request),
+        mode,
+        message: elicitation.request.message.clone(),
+        requested_schema,
+        status: crate::types::elicitation_status_str(&elicitation.status).to_string(),
+        timestamp: chrono::Utc::now().timestamp(),
+    })
+    .log_err();
+}
+
+/// Report an elicitation's current status. Emitted on every terminal transition so the
+/// Helix card stops being answerable the moment the question is gone, whatever resolved
+/// it (an answer, a skip, turn teardown, or a follow-up prompt).
+///
+/// `content` is always None: `ElicitationStatus::Accepted` is a unit variant, so Zed does
+/// not retain what was submitted. Helix persists the answer it sent instead.
+fn send_elicitation_resolved(
+    thread: &AcpThread,
+    acp_thread_id: &str,
+    request_id: &str,
+    elicitation_id: &acp_thread::ElicitationEntryId,
+) {
+    let Some((entry_index, elicitation)) = thread.elicitation(elicitation_id) else {
+        return;
+    };
+    let status = crate::types::elicitation_status_str(&elicitation.status);
+    if status == "pending" {
+        return;
+    }
+    log::info!(
+        "[ELICITATION] {} resolved as {} on thread {}",
+        elicitation_id.0,
+        status,
+        acp_thread_id
+    );
+    crate::send_websocket_event(SyncEvent::ElicitationResolved {
+        acp_thread_id: acp_thread_id.to_string(),
+        request_id: request_id.to_string(),
+        entry_index: entry_index.to_string(),
+        elicitation_id: elicitation_id.0.to_string(),
+        status: status.to_string(),
+        content: None,
+        timestamp: chrono::Utc::now().timestamp(),
+    })
+    .log_err();
+}
+
+fn send_elicitation_ack(elicitation_id: &str, status: &str, error: &str) {
+    crate::send_websocket_event(SyncEvent::ElicitationResponseAck {
+        elicitation_id: elicitation_id.to_string(),
+        status: status.to_string(),
+        error: error.to_string(),
+    })
+    .log_err();
+}
+
+/// Convert one JSON answer into the typed value ACP expects. Returns None for shapes
+/// that have no ACP equivalent, so a malformed field is skipped rather than failing the
+/// whole answer.
+fn elicitation_content_value(value: &serde_json::Value) -> Option<acp::ElicitationContentValue> {
+    match value {
+        serde_json::Value::String(text) => Some(text.clone().into()),
+        serde_json::Value::Bool(flag) => Some((*flag).into()),
+        serde_json::Value::Number(number) => {
+            if let Some(int) = number.as_i64() {
+                Some(int.into())
+            } else {
+                number.as_f64().map(Into::into)
+            }
+        }
+        // Multi-select. Non-string members can't be represented, so they're dropped.
+        serde_json::Value::Array(items) => Some(
+            items
+                .iter()
+                .filter_map(|item| item.as_str().map(str::to_string))
+                .collect::<Vec<String>>()
+                .into(),
+        ),
+        _ => None,
+    }
+}
+
+/// Build the ACP response for a user's answer.
+///
+/// `decline` is deliberately NOT an abort: the adapter turns it into an empty answers map
+/// and the agent's turn continues, which is why the Helix UI labels it "Skip".
+fn build_elicitation_response(
+    request: &crate::ElicitationResponseRequest,
+) -> Result<acp::CreateElicitationResponse> {
+    match request.action.as_str() {
+        "accept" => {
+            let mut content = std::collections::BTreeMap::new();
+            if let Some(serde_json::Value::Object(fields)) = &request.content {
+                for (name, value) in fields {
+                    if let Some(value) = elicitation_content_value(value) {
+                        content.insert(name.clone(), value);
+                    }
+                }
+            }
+            Ok(acp::CreateElicitationResponse::new(
+                acp::ElicitationAction::Accept(
+                    acp::ElicitationAcceptAction::new().content(content),
+                ),
+            ))
+        }
+        "decline" => Ok(acp::CreateElicitationResponse::new(
+            acp::ElicitationAction::Decline,
+        )),
+        "cancel" => Ok(acp::CreateElicitationResponse::new(
+            acp::ElicitationAction::Cancel,
+        )),
+        other => anyhow::bail!("unsupported elicitation action: {}", other),
+    }
+}
+
+/// How often a thread holding a pending question tells Helix it still holds it.
+/// Must stay comfortably below Helix's reap grace window.
+const ELICITATION_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Report which elicitations this thread still holds.
+///
+/// This is what lets Helix tell "the agent died" from "the API restarted". A reconnect on
+/// its own proves nothing — `agent_ready` fires whenever the WebSocket comes back, and the
+/// commonest cause is the Helix API restarting while this process and its `respond_tx`
+/// live on. So instead of treating a reconnect as evidence, the thread that owns a pending
+/// question keeps saying so; Helix reaps a question only when those statements stop.
+///
+/// `announce_full` re-sends each question's full payload, which a Helix that lost its
+/// state needs. The periodic heartbeat sends only the id list, to avoid republishing
+/// transcript entries every few seconds.
+pub fn resync_elicitations(acp_thread_id: &str, thread: &AcpThread, announce_full: bool) -> usize {
+    let request_id = get_thread_request_id(acp_thread_id).unwrap_or_default();
+    let mut pending_ids = Vec::new();
+    for entry in thread.entries() {
+        let acp_thread::AgentThreadEntry::Elicitation(elicitation_id) = entry else {
+            continue;
+        };
+        let Some((_, elicitation)) = thread.elicitation(elicitation_id) else {
+            continue;
+        };
+        if !matches!(
+            elicitation.status,
+            acp_thread::ElicitationStatus::Pending { .. }
+        ) {
+            continue;
+        }
+        if announce_full {
+            send_elicitation_requested(thread, acp_thread_id, &request_id, elicitation_id);
+        }
+        pending_ids.push(elicitation_id.0.to_string());
+    }
+
+    // An empty list is meaningful — it tells Helix this thread holds nothing, so any
+    // question it still thinks is pending here is gone. Always send it.
+    let pending_count = pending_ids.len();
+    crate::send_websocket_event(SyncEvent::ElicitationResync {
+        acp_thread_id: acp_thread_id.to_string(),
+        elicitation_ids: pending_ids,
+        timestamp: chrono::Utc::now().timestamp(),
+    })
+    .log_err();
+    pending_count
+}
+
+/// Resync every registered thread. Returns how many questions are outstanding overall.
+pub fn resync_all_elicitations(cx: &mut App, announce_full: bool) -> usize {
+    let Some(registry) = THREAD_REGISTRY.lock().clone() else {
+        return 0;
+    };
+    let threads: Vec<(String, Entity<AcpThread>)> = registry
+        .read()
+        .iter()
+        .map(|(id, thread)| (id.clone(), thread.clone()))
+        .collect();
+    threads
+        .into_iter()
+        .map(|(acp_thread_id, thread)| {
+            resync_elicitations(&acp_thread_id, thread.read(cx), announce_full)
+        })
+        .sum()
+}
+
 /// Flush all pending throttled messages for a given thread and clean up throttle state.
 /// Called before message_completed to ensure the final content is sent.
 pub fn flush_streaming_throttle(acp_thread_id: &str) {
@@ -1047,8 +1290,35 @@ pub fn ensure_thread_subscription(
                     });
                 }
             }
+            // An ACP agent asked the user a question. Without these arms the
+            // elicitation entry is dropped and Helix only ever sees the dead
+            // tool-call stub the adapter emitted just before it.
+            AcpThreadEvent::ElicitationRequested(elicitation_id) => {
+                let thread = thread_entity.read(cx);
+                let rid = turn_request_id.borrow().clone();
+                send_elicitation_requested(thread, &thread_id_for_sub, &rid, elicitation_id);
+            }
+            AcpThreadEvent::ElicitationResponded(elicitation_id) => {
+                let thread = thread_entity.read(cx);
+                let rid = turn_request_id.borrow().clone();
+                send_elicitation_resolved(thread, &thread_id_for_sub, &rid, elicitation_id);
+            }
             AcpThreadEvent::EntryUpdated(entry_idx) => {
                 let thread = thread_entity.read(cx);
+                // Elicitation status changes (answered, skipped, cancelled by turn
+                // teardown or by a follow-up prompt) arrive as EntryUpdated, not as a
+                // dedicated event — `respond_to_elicitation` and `cancel_elicitation`
+                // both emit only this. Resolving it here is what keeps the Helix card
+                // from staying answerable after the question is gone. Duplicate
+                // resolved events (this + ElicitationResponded) are harmless: the Go
+                // side applies them as conditional updates.
+                if let Some(acp_thread::AgentThreadEntry::Elicitation(elicitation_id)) =
+                    thread.entries().get(*entry_idx)
+                {
+                    let rid = turn_request_id.borrow().clone();
+                    send_elicitation_resolved(thread, &thread_id_for_sub, &rid, elicitation_id);
+                    return;
+                }
                 if let Some(entry) = thread.entries().get(*entry_idx) {
                     let (content, entry_type, tool_name, tool_status) = match entry {
                         acp_thread::AgentThreadEntry::AssistantMessage(msg) => {
@@ -1480,6 +1750,133 @@ pub fn setup_thread_handler(
             }
         }
     }).detach();
+
+    // Heartbeat for outstanding questions. A thread that holds a pending elicitation
+    // keeps telling Helix so; Helix reaps a question only when those statements stop for
+    // longer than its grace window. Without this, Helix could not distinguish a question
+    // whose agent died from one the user is simply taking a while to answer.
+    //
+    // Also drains resync requests raised when the WebSocket reconnects, which re-announce
+    // full payloads so a Helix that lost its state can rebuild it.
+    let (resync_tx, mut resync_rx) = mpsc::unbounded_channel::<()>();
+    crate::init_elicitation_resync_callback(resync_tx);
+    cx.spawn(async move |cx| {
+        log::info!("[ELICITATION] Heartbeat task started");
+        loop {
+            // GPUI's timer, not tokio's — this task runs on GPUI's executor, where a
+            // tokio timer has no reactor to register with.
+            cx.background_executor()
+                .timer(ELICITATION_HEARTBEAT_INTERVAL)
+                .await;
+
+            // Any reconnect since the last tick means Helix may have lost its state, so
+            // re-announce the full payloads rather than just the id list. Drain the
+            // channel so a burst of reconnects collapses into one announce.
+            let mut announce_full = false;
+            while resync_rx.try_recv().is_ok() {
+                announce_full = true;
+            }
+
+            match cx.update(|cx| resync_all_elicitations(cx, announce_full)) {
+                Ok(count) if count > 0 => {
+                    log::info!("[ELICITATION] Heartbeat: {} question(s) outstanding", count);
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    log::warn!("[ELICITATION] Heartbeat stopping: {}", e);
+                    return;
+                }
+            }
+        }
+    })
+    .detach();
+
+    // Spawn dedicated elicitation-response task. Like the cancel task, this must run
+    // independently of the callback_rx loop: that loop is blocked awaiting the very turn
+    // that is waiting for this answer, so routing through it would deadlock.
+    let (elicitation_tx, mut elicitation_rx) =
+        mpsc::unbounded_channel::<crate::ElicitationResponseRequest>();
+    crate::init_elicitation_response_callback(elicitation_tx);
+    cx.spawn(async move |cx| {
+        log::info!("[ELICITATION] Response task started");
+        while let Some(request) = elicitation_rx.recv().await {
+            let elicitation_id = acp_thread::ElicitationEntryId(
+                request.elicitation_id.clone().into(),
+            );
+
+            let Some(thread) = crate::get_thread(&request.acp_thread_id) else {
+                log::warn!(
+                    "[ELICITATION] Thread {} not in registry; cannot answer {}",
+                    request.acp_thread_id,
+                    request.elicitation_id
+                );
+                send_elicitation_ack(&request.elicitation_id, "not_found", "thread not found");
+                continue;
+            };
+
+            let response = match build_elicitation_response(&request) {
+                Ok(response) => response,
+                Err(e) => {
+                    log::warn!(
+                        "[ELICITATION] Rejecting answer for {}: {}",
+                        request.elicitation_id,
+                        e
+                    );
+                    send_elicitation_ack(&request.elicitation_id, "noop", &e.to_string());
+                    continue;
+                }
+            };
+
+            // Snapshot the status either side of the update. `respond_to_elicitation`
+            // is already a safe no-op for an unknown id or an already-resolved
+            // question, but it returns nothing — comparing tells us which happened so
+            // we can report it instead of leaving Helix guessing.
+            let result = cx.update(|cx| {
+                thread.update(cx, |thread, cx| {
+                    let was_pending = thread.elicitation(&elicitation_id).is_some_and(
+                        |(_, elicitation)| {
+                            matches!(
+                                elicitation.status,
+                                acp_thread::ElicitationStatus::Pending { .. }
+                            )
+                        },
+                    );
+                    if !was_pending {
+                        return thread
+                            .elicitation(&elicitation_id)
+                            .map_or("not_found", |_| "noop");
+                    }
+                    thread.respond_to_elicitation(&elicitation_id, response, cx);
+                    "accepted"
+                })
+            });
+
+            match result {
+                Ok(Ok(status)) => {
+                    log::info!(
+                        "[ELICITATION] Answer for {} → {}",
+                        request.elicitation_id,
+                        status
+                    );
+                    let error = match status {
+                        "noop" => "elicitation already resolved",
+                        "not_found" => "elicitation not found on thread",
+                        _ => "",
+                    };
+                    send_elicitation_ack(&request.elicitation_id, status, error);
+                }
+                Ok(Err(e)) | Err(e) => {
+                    log::warn!(
+                        "[ELICITATION] Failed to answer {}: {}",
+                        request.elicitation_id,
+                        e
+                    );
+                    send_elicitation_ack(&request.elicitation_id, "not_found", &e.to_string());
+                }
+            }
+        }
+    })
+    .detach();
 
     // Spawn handler task to process thread creation requests
     cx.spawn(async move |cx| {

--- a/crates/external_websocket_sync/src/types.rs
+++ b/crates/external_websocket_sync/src/types.rs
@@ -277,6 +277,58 @@ pub enum SyncEvent {
         /// Currently selected model ID for the active thread (if available)
         active_model: Option<String>,
     },
+    /// An ACP agent asked the user a question (`session/request_elicitation`).
+    /// The turn is blocked until Helix answers via the `respond_elicitation` command.
+    /// Re-emitted verbatim on reconnect for elicitations that are still pending, so a
+    /// Helix that restarted can rebuild its view without inventing state.
+    #[serde(rename = "elicitation_requested")]
+    ElicitationRequested {
+        acp_thread_id: String,
+        request_id: String,
+        /// Position in `AcpThread::entries()` — the same value used as `message_id` for
+        /// `message_added`, so Helix can slot the question into the transcript in order.
+        entry_index: String,
+        elicitation_id: String,
+        tool_call_id: String,
+        mode: String,
+        message: String,
+        /// The full `requestedSchema`, passed through verbatim. Helix renders from this,
+        /// so flattening it here would silently drop options the agent offered.
+        requested_schema: serde_json::Value,
+        status: String,
+        timestamp: i64,
+    },
+    /// An elicitation reached a terminal status — answered, skipped, or cancelled by turn
+    /// teardown / a follow-up prompt. Helix stops offering to answer on receipt.
+    #[serde(rename = "elicitation_resolved")]
+    ElicitationResolved {
+        acp_thread_id: String,
+        request_id: String,
+        entry_index: String,
+        elicitation_id: String,
+        status: String,
+        content: Option<serde_json::Value>,
+        timestamp: i64,
+    },
+    /// Completeness marker sent after re-announcing pending elicitations on reconnect.
+    /// Lists every elicitation this thread still holds (an empty list is meaningful).
+    /// Helix reaps its own pending rows that are absent from this list — the only
+    /// evidence-based way to tell "the agent died" from "the API restarted".
+    #[serde(rename = "elicitation_resync")]
+    ElicitationResync {
+        acp_thread_id: String,
+        elicitation_ids: Vec<String>,
+        timestamp: i64,
+    },
+    /// Reply to a `respond_elicitation` command. `noop` means the elicitation was no longer
+    /// pending (already answered, or cancelled); `not_found` means the id or its thread is
+    /// gone. Both are clean outcomes, not errors that should wedge a turn.
+    #[serde(rename = "elicitation_response_ack")]
+    ElicitationResponseAck {
+        elicitation_id: String,
+        status: String,
+        error: String,
+    },
 }
 
 impl SyncEvent {
@@ -368,10 +420,83 @@ impl SyncEvent {
                     "active_model": active_model,
                 })
             ),
+            SyncEvent::ElicitationRequested {
+                acp_thread_id, request_id, entry_index, elicitation_id, tool_call_id,
+                mode, message, requested_schema, status, timestamp,
+            } => (
+                "elicitation_requested".to_string(),
+                serde_json::json!({
+                    "acp_thread_id": acp_thread_id,
+                    "request_id": request_id,
+                    "entry_index": entry_index,
+                    "elicitation_id": elicitation_id,
+                    "tool_call_id": tool_call_id,
+                    "mode": mode,
+                    "message": message,
+                    "requested_schema": requested_schema,
+                    "status": status,
+                    "timestamp": timestamp,
+                })
+            ),
+            SyncEvent::ElicitationResolved {
+                acp_thread_id, request_id, entry_index, elicitation_id, status, content, timestamp,
+            } => (
+                "elicitation_resolved".to_string(),
+                serde_json::json!({
+                    "acp_thread_id": acp_thread_id,
+                    "request_id": request_id,
+                    "entry_index": entry_index,
+                    "elicitation_id": elicitation_id,
+                    "status": status,
+                    "content": content,
+                    "timestamp": timestamp,
+                })
+            ),
+            SyncEvent::ElicitationResync { acp_thread_id, elicitation_ids, timestamp } => (
+                "elicitation_resync".to_string(),
+                serde_json::json!({
+                    "acp_thread_id": acp_thread_id,
+                    "elicitation_ids": elicitation_ids,
+                    "timestamp": timestamp,
+                })
+            ),
+            SyncEvent::ElicitationResponseAck { elicitation_id, status, error } => (
+                "elicitation_response_ack".to_string(),
+                serde_json::json!({
+                    "elicitation_id": elicitation_id,
+                    "status": status,
+                    "error": error,
+                })
+            ),
         };
 
         Ok(OutgoingMessage { event_type, data })
     }
+}
+
+/// Wire spelling for an elicitation status. Zed spells the cancelled state `Canceled`;
+/// the wire protocol uses `cancelled`. This is the ONLY place the two spellings meet —
+/// keep it that way.
+pub fn elicitation_status_str(status: &acp_thread::ElicitationStatus) -> &'static str {
+    match status {
+        acp_thread::ElicitationStatus::Pending { .. } => "pending",
+        acp_thread::ElicitationStatus::Accepted => "accepted",
+        acp_thread::ElicitationStatus::Declined => "declined",
+        acp_thread::ElicitationStatus::Canceled => "cancelled",
+        acp_thread::ElicitationStatus::Completed => "completed",
+    }
+}
+
+/// A request from Helix to answer a pending elicitation, delivered as the
+/// `respond_elicitation` command.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct IncomingElicitationResponse {
+    pub acp_thread_id: String,
+    pub elicitation_id: String,
+    /// "accept" | "decline". "cancel" is reserved for teardown and is not sent by users.
+    pub action: String,
+    #[serde(default)]
+    pub content: Option<serde_json::Value>,
 }
 
 /// Incoming command from external system to Zed

--- a/crates/external_websocket_sync/src/websocket_sync.rs
+++ b/crates/external_websocket_sync/src/websocket_sync.rs
@@ -161,6 +161,11 @@ impl WebSocketSync {
                     eprintln!("✅ [WEBSOCKET] Connected! Running message loop...");
                     log::info!("✅ [WEBSOCKET] Connected! Running message loop...");
 
+                    // The Helix on the other end may have restarted and lost track of
+                    // which questions are still outstanding. Re-announce them in full so
+                    // it can rebuild rather than guess.
+                    crate::request_elicitation_resync();
+
                     // Run until connection drops
                     Self::run_connection(ws_sink, ws_stream, &mut outgoing_rx).await;
 
@@ -403,6 +408,7 @@ impl WebSocketSync {
             "open_thread" => Self::handle_open_thread(command.data).await,
             "query_ui_state" => Self::handle_query_ui_state(command.data).await,
             "cancel_current_turn" => Self::handle_cancel_current_turn(command.data).await,
+            "respond_elicitation" => Self::handle_respond_elicitation(command.data).await,
             _ => {
                 eprintln!("⚠️  [WEBSOCKET-IN] Ignoring unknown command: {}", command.command_type);
                 log::warn!("⚠️  [WEBSOCKET-IN] Ignoring unknown command: {}", command.command_type);
@@ -567,6 +573,26 @@ impl WebSocketSync {
         crate::request_thread_cancellation(crate::CancellationRequest { request_id })?;
 
         Ok(())
+    }
+
+    /// Handle respond_elicitation command — the user answered a question the agent asked.
+    async fn handle_respond_elicitation(data: serde_json::Value) -> Result<()> {
+        let response: crate::IncomingElicitationResponse = serde_json::from_value(data)
+            .context("Failed to parse respond_elicitation data")?;
+
+        log::info!(
+            "[WEBSOCKET-IN] Processing respond_elicitation: thread={} elicitation={} action={}",
+            response.acp_thread_id,
+            response.elicitation_id,
+            response.action
+        );
+
+        crate::request_elicitation_response(crate::ElicitationResponseRequest {
+            acp_thread_id: response.acp_thread_id,
+            elicitation_id: response.elicitation_id,
+            action: response.action,
+            content: response.content,
+        })
     }
 
     /// Send event to external system


### PR DESCRIPTION
Finish the feature described below. Most of it is already committed on the branch you are starting on — read it before writing anything.

# Finish the agent-questions (ACP elicitation) feature — it is ~70% built already

This continues task 002731, whose sandbox lost its agent connection permanently before the
work could be finished. **All of the code that exists is already committed and pushed** to
the project git server on the branch `feature/002731-end-to-end-agent` **in both the `helix`
and `zed` repos**. You are starting on that branch. Do not re-implement any of it; read it
first, then finish the remaining items.

Run this before anything else, in both repos, and read what is there:

```
git log --oneline -3
git show --stat HEAD
```

- `helix`: `0cc5290ce` (design doc) on top of `9ddbd5d74` "feat(api): record and answer
  agent questions from ACP elicitations" — 2492 insertions across 23 files.
- `zed`: `8fbf40ad92` "feat(external_websocket_sync): mirror ACP elicitations to Helix and
  accept answers" — 629 insertions across 4 files.

The full design lives in `design/2026-08-11-agent-questions-elicitation.md` (committed) and
in `design/tasks/002731_*/{requirements,design,tasks}.md` in the helix-specs repo. Those
were reviewed and approved; follow them.

## What the feature is

Claude Code asks the user a question mid-turn via its built-in `AskUserQuestion` tool. The
`claude-agent-acp` adapter turns that into an ACP **form elicitation** and blocks the turn
until the client answers. Helix could not see or answer those questions at all —
`crates/external_websocket_sync/` dropped `AgentThreadEntry::Elicitation` on the floor, and
`grep -rn elicitation api/` returned nothing. The committed work adds: the Zed→Helix sync
events, a `respond_elicitation` command back to Zed, an `agent_elicitations` store, a REST
endpoint, and a React card that renders the question's options and submits an answer.

**The Zed agent panel's own elicitation UI is known-broken and deliberately staying broken**
(it draws the card with no option controls and no text field). Helix must work without it.
Do not fix it, do not depend on it, and do not rebase Zed onto upstream.

## What is left — this is your whole job

1. **`./stack update_openapi` has never been run, and the frontend cannot build without it.**
   `frontend/src/services/elicitationService.ts` imports `TypesElicitationRespondResponse`
   and calls `client.v1SessionsElicitationsRespondCreate` / `v1SessionsElicitationsDetail`,
   but `grep -c "v1SessionsElicitationsRespondCreate" frontend/src/api/api.ts` returns `0`.
   Regenerate and commit the generated files, then confirm `cd frontend && yarn build` is
   clean.

2. **Go tests.** None exist yet. Write them in the `suite.Suite` + gomock style of
   `api/pkg/server/websocket_external_agent_sync_test.go`, covering: the
   `elicitation_requested` / `elicitation_resolved` / `elicitation_resync` /
   `elicitation_response_ack` handlers; the REST endpoint's auth and 404/403/409 paths; two
   clients answering at once; an answer arriving after cancel; the empty-`request_id`
   fallback; **reconnect-does-not-cancel** and resync-absence-does-cancel-after-grace; and
   `TestAutoWake_SkipsInteractionBlockedOnUserQuestion`. Run them.

3. **E2E phase.** Add Phase 17 to
   `zed/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go`:
   elicitation_requested (assert a non-empty schema) → `respond_elicitation` →
   `elicitation_resolved(accepted)` → `message_completed` for the same turn. Drive it
   through the **synthetic** seam — do not make a CI phase depend on the model choosing to
   call a tool; say so in the phase comment. Then **run the full dockerized suite**
   (`./run_docker_e2e.sh`) and see it green. `CLAUDE.md` is absolute on this: if you touch
   the e2e tests you must run them. "It compiles" and "it follows the pattern" are not
   evidence.

4. **`sandbox-versions.txt`** — bump `ZED_COMMIT` to your final zed commit.

5. **Live end-to-end verification in this inner Helix, with screenshots.** This is the part
   that actually proves the feature and it has never been done:
   - get an agent to call `AskUserQuestion`;
   - the question renders in the **Helix** UI with every option — screenshot;
   - answer it in Helix, the turn resumes reflecting that answer — screenshot;
   - then the next operation: a normal follow-up message is delivered and answered, and a
     second question in the same session works;
   - the decline path settles cleanly;
   - a question left unanswered and then interrupted from Helix settles and stops being
     answerable.

   If any of these fail, fix them or say plainly which ones do not work. Do not report the
   feature as done on the strength of unit tests.

## Then ship it

Merge order from `CLAUDE.md`, exactly: commit in zed (do not push yet) → `git rev-parse HEAD`
→ bump `ZED_COMMIT` in `sandbox-versions.txt` → open the **Helix** PR first → push the zed
branch and open its PR with `gh pr create --repo helixml/zed` → CI green on both → merge zed
first, then helix. Rebase if `ZED_COMMIT` has moved.

## Environment warnings, learned the hard way on the last attempt

- The previous sandbox's agent connection died and never came back, taking a six-hour turn
  with it. **Commit and push early and often** — every meaningful chunk of work, pushed to
  the project git server. Do not accumulate hours of uncommitted work.
- Do not use long blind `sleep`s (the last attempt sat in `sleep 540` waiting on a build).
  Poll in a loop with a short interval so you notice a build that finished or died.
- Builds here are heavy and the box is shared. Prefer targeted `go build ./pkg/...` and
  package-scoped tests over full-workspace builds where you can.


---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kzsaa2bbvvp4qwfkrhw21ksb)

📋 Spec:
- [Requirements](https://github.com/helixml/zed/blob/helix-specs/design/tasks/002750_finish-agent-questions/requirements.md)
- [Design](https://github.com/helixml/zed/blob/helix-specs/design/tasks/002750_finish-agent-questions/design.md)
- [Tasks](https://github.com/helixml/zed/blob/helix-specs/design/tasks/002750_finish-agent-questions/tasks.md)

🚀 Built with [Helix](https://helix.ml)