### PR TITLE
fix(acp): carry the cause on AcpThreadEvent::Error

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -2199,7 +2199,16 @@ pub enum AcpThreadEvent {
     Retry(RetryStatus),
     SubagentSpawned(acp::SessionId),
     Stopped(acp::StopReason),
-    Error,
+    /// A turn ended abnormally. The payload is the cause, in human-readable
+    /// form: the underlying `run_turn` error, or the max-tokens explanation.
+    ///
+    /// This used to be a bare variant, which forced every downstream consumer
+    /// to guess between "the agent process died" and "the turn hit max
+    /// tokens" — Helix surfaced that guess to users as a single unactionable
+    /// string telling them to read a log file inside a sandbox that no longer
+    /// exists. The cause is known at every emit site, so it travels with the
+    /// event.
+    Error(SharedString),
     LoadError(LoadError),
     PromptCapabilitiesUpdated,
     Refusal,
@@ -3851,7 +3860,9 @@ impl AcpThread {
                                 cx.emit(AcpThreadEvent::StatusChanged);
                             }
                             this.had_error = true;
-                            cx.emit(AcpThreadEvent::Error);
+                            cx.emit(AcpThreadEvent::Error(
+                                "the turn hit the model's max token limit".into(),
+                            ));
                             log::error!("Max tokens reached. Usage: {:?}", this.token_usage);
 
                             let exceeded_max_output_tokens =
@@ -3965,7 +3976,7 @@ impl AcpThread {
                             this.cancel_pending_turn_entries(cx);
                         }
                         this.had_error = true;
-                        cx.emit(AcpThreadEvent::Error);
+                        cx.emit(AcpThreadEvent::Error(format!("{e:#}").into()));
                         log::error!("Error in run turn: {:?}", e);
                         Err(e)
                     }

--- a/crates/agent_ui/src/agent_diff.rs
+++ b/crates/agent_ui/src/agent_diff.rs
@@ -1478,7 +1478,7 @@ impl AgentDiff {
             AcpThreadEvent::Stopped(_) => {
                 self.update_reviewing_editors(workspace, window, cx);
             }
-            AcpThreadEvent::Error | AcpThreadEvent::LoadError(_) | AcpThreadEvent::Refusal => {
+            AcpThreadEvent::Error(_) | AcpThreadEvent::LoadError(_) | AcpThreadEvent::Refusal => {
                 self.update_reviewing_editors(workspace, window, cx);
             }
             AcpThreadEvent::TitleUpdated

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -320,7 +320,7 @@ impl Conversation {
                     | AcpThreadEvent::Retry(_)
                     | AcpThreadEvent::SubagentSpawned(_)
                     | AcpThreadEvent::Stopped(_)
-                    | AcpThreadEvent::Error
+                    | AcpThreadEvent::Error(_)
                     | AcpThreadEvent::LoadError(_)
                     | AcpThreadEvent::PromptCapabilitiesUpdated
                     | AcpThreadEvent::Refusal
@@ -568,7 +568,7 @@ fn affects_thread_metadata(event: &AcpThreadEvent) -> bool {
         | AcpThreadEvent::ElicitationRequested(_)
         | AcpThreadEvent::ElicitationResponded(_)
         | AcpThreadEvent::Stopped(_)
-        | AcpThreadEvent::Error
+        | AcpThreadEvent::Error(_)
         | AcpThreadEvent::LoadError(_)
         | AcpThreadEvent::Refusal
         | AcpThreadEvent::WorkingDirectoriesUpdated => true,
@@ -2126,7 +2126,7 @@ impl ConversationView {
                     self.notify_with_sound(&notification_message, IconName::Warning, window, cx);
                 }
             }
-            AcpThreadEvent::Error => {
+            AcpThreadEvent::Error(_) => {
                 if let Some(active) = self.thread_view(&session_id) {
                     let is_generating =
                         matches!(thread.read(cx).status(), ThreadStatus::Generating);

--- a/crates/eval_cli/src/main.rs
+++ b/crates/eval_cli/src/main.rs
@@ -1006,8 +1006,8 @@ fn log_acp_thread_event(
         acp_thread::AcpThreadEvent::Stopped(reason) => {
             eprintln!("\n[eval-cli] stopped: {reason:?}");
         }
-        acp_thread::AcpThreadEvent::Error => {
-            eprintln!("[eval-cli] error event");
+        acp_thread::AcpThreadEvent::Error(cause) => {
+            eprintln!("[eval-cli] error event: {cause}");
         }
         acp_thread::AcpThreadEvent::Retry(status) => {
             eprintln!("[eval-cli] retry: {status:?}");

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -1145,8 +1145,11 @@ pub fn ensure_thread_subscription(
             // Error (agent process exited mid-turn, or MaxTokens — run_turn's Err
             // arm) → chat_response_error. Without the Error arm a crashed agent
             // that streamed partial output wedges the worker forever.
-            AcpThreadEvent::Stopped(_) | AcpThreadEvent::Error => {
-                let is_error = matches!(event, AcpThreadEvent::Error);
+            AcpThreadEvent::Stopped(_) | AcpThreadEvent::Error(_) => {
+                let abort_cause = match event {
+                    AcpThreadEvent::Error(cause) => Some(cause.clone()),
+                    _ => None,
+                };
                 flush_streaming_throttle(&thread_id_for_sub);
 
                 // AcpThread calls flush_streaming_text before emitting Stopped/Error, so all
@@ -1230,18 +1233,18 @@ pub fn ensure_thread_subscription(
                     captured_rid
                 };
                 *last_completed_request_id.borrow_mut() = completed_rid.clone();
-                if is_error {
+                if let Some(cause) = abort_cause {
                     // Turn aborted (agent process exited mid-turn, or MaxTokens).
                     // Emit chat_response_error, NOT message_completed: Helix's
                     // handleChatResponseError marks the interaction state=error
                     // (vs masking a crash as a normal completion) and ends the
                     // activation, freeing the per-Worker lane.
                     //
-                    // AcpThreadEvent::Error carries no cause string, so the
-                    // payload is generic — the real exit reason (e.g. "process
-                    // exited with code 143") is logged by acp_thread::run_turn
-                    // just before this fires: grep Zed.log for "Error in run
-                    // turn" near this request_id. We also log the
+                    // AcpThreadEvent::Error carries the cause (the run_turn
+                    // error, or the max-tokens explanation), so it goes on the
+                    // wire and Helix can show the user what actually happened
+                    // instead of a guess pointing at a log inside a sandbox
+                    // that no longer exists. We also log the
                     // streamed-then-died signal (partial entry count + bytes) so
                     // a future wedge is identifiable from Zed.log alone, without
                     // reconstructing it from Helix DB state.
@@ -1259,15 +1262,14 @@ pub fn ensure_thread_subscription(
                         .sum();
                     log::warn!(
                         "🛑 [THREAD_SERVICE] turn ABORTED (AcpThreadEvent::Error) thread={} request_id={} \
-                         streamed {} partial entries / {} bytes before dying — emitting chat_response_error \
-                         to mark the interaction errored and free the Helix activation lane",
-                        thread_id_for_sub, completed_rid, turn_entries, partial_bytes
+                         cause={} streamed {} partial entries / {} bytes before dying — emitting \
+                         chat_response_error to mark the interaction errored and free the Helix \
+                         activation lane",
+                        thread_id_for_sub, completed_rid, cause, turn_entries, partial_bytes
                     );
                     let _ = crate::send_websocket_event(SyncEvent::ChatResponseError {
                         request_id: completed_rid,
-                        error: "agent turn aborted: the ACP agent process exited mid-turn or hit \
-                                max tokens (see Zed.log 'Error in run turn' for the cause)"
-                            .to_string(),
+                        error: format!("agent turn aborted: {cause}"),
                     });
                 } else {
                     eprintln!(

--- a/crates/external_websocket_sync/src/types.rs
+++ b/crates/external_websocket_sync/src/types.rs
@@ -247,6 +247,11 @@ pub enum SyncEvent {
     /// Sent when a turn aborts (ACP agent process exited mid-turn, or MaxTokens).
     /// Helix's handleChatResponseError marks the interaction state=error with
     /// this message and ends the activation, freeing the per-Worker lane.
+    ///
+    /// `error` carries the real cause, taken from `AcpThreadEvent::Error`'s
+    /// payload — a provider error, a process exit, or the max-token limit.
+    /// Helix shows it to the user verbatim, so it must name what went wrong
+    /// rather than tell the reader to go and find a log.
     #[serde(rename = "chat_response_error")]
     ChatResponseError {
         request_id: String,


### PR DESCRIPTION
Paired with https://github.com/helixml/helix/pull/3064, which pins this commit in `sandbox-versions.txt`. **Merge this one first.**

## The problem

`AcpThreadEvent::Error` was a payload-free variant. Both emit sites know exactly why the turn ended — the max-tokens branch, and the `run_turn` `Err` arm which logs the error on the very next line — but neither could pass it on. So `thread_service` could only send Helix a guess:

```
agent turn aborted: the ACP agent process exited mid-turn or hit max tokens
(see Zed.log 'Error in run turn' for the cause)
```

Two different failures conflated into one string, pointing at a log file inside a sandbox container that is deleted when the task ends. The user cannot reach it.

## Motivating incident

On 2026-08-18 a 42-second upstream outage (Caddy returning `502 upstream unavailable` while a vLLM backend restarted) aborted five spec tasks. Every one reported the string above, while Helix had `502 upstream unavailable` sitting in `llm_calls` the whole time. Nobody could tell from the UI that the cause was a provider blip rather than a broken task.

## The change

`Error(SharedString)` carrying the cause:

- max-tokens site → `"the turn hit the model's max token limit"`
- `run_turn` Err site → `format!("{e:#}")`

`thread_service` matches on the payload and puts it straight into `ChatResponseError`, so Helix shows the user what actually happened. The abort warning log gains the cause too, so a future wedge is diagnosable from `Zed.log` alone. The `ChatResponseError` doc comment in `types.rs` now records that the field must name what went wrong rather than tell the reader to go and find a log.

Consumers updated: `thread_service`, `agent_diff`, `conversation_view` (3 sites), `eval_cli` (which now prints the cause).

## Testing

Dockerized E2E, **all 17 phases pass** against a binary built from this commit, including the ones this change could plausibly have broken — phase 8 (mid-stream interrupt), phase 9 (rapid 3-turn cancel), phase 13 (Helix-initiated cancel).

```
Phase 1–17: PASSED    [store] PASSED    ALL TESTS PASSED
```

Run with `E2E_MODEL_PROVIDER=openai E2E_MODEL=gpt-5.2` — this environment's key does not serve `anthropic/claude-sonnet-4-6`. Env override only, no file edit.

Two things worth knowing for anyone else running it:

- `run_docker_e2e.sh` reported **exit 0** on a run whose own banner said `PHASE 1 TIMED OUT` / `ABORTING`. Don't trust the exit code alone — read the banner.
- `cargo check` on `acp_thread`, `external_websocket_sync`, `agent_ui`, `eval_cli` is clean; the one remaining warning in the workspace (`migrator` unused import) is pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
