### PR TITLE
fix(sync): release a turn's lane when its thread cannot be loaded

### DIFF
--- a/crates/external_websocket_sync/src/external_websocket_sync.rs
+++ b/crates/external_websocket_sync/src/external_websocket_sync.rs
@@ -206,6 +206,30 @@ fn register_queued_request(request_id: &str, acp_thread_id: Option<&str>) -> Req
     }
 }
 
+/// Drop a turn's ingress registration after refusing it before it ever ran.
+///
+/// `register_queued_request` admits a turn at ingress and only
+/// `RequestLifecycleGuard::drop` clears it — and the guard is created when a
+/// prompt actually STARTS. A turn refused before that (the thread could not be
+/// loaded, and for an agent with no `loadSession` capability it never will be)
+/// therefore leaks a Queued entry that never drops, so every later delivery of
+/// that same turn is rejected as a duplicate. Helix's recovery replays such a
+/// turn under its original request_id, which made the replay silently
+/// unreachable and left the interaction waiting forever.
+///
+/// Only a Queued entry is dropped. A Running one belongs to a live turn (a
+/// duplicate is already refused at ingress and never reaches the refusal path),
+/// and a Cancelled one is a tombstone `start_registered_request` must still
+/// consume.
+pub(crate) fn abandon_queued_request(request_id: &str) {
+    let mut requests = REQUEST_LIFECYCLES.lock();
+    if let Some(tracked) = requests.get(request_id) {
+        if tracked.lifecycle == RequestLifecycle::Queued {
+            requests.remove(request_id);
+        }
+    }
+}
+
 fn cancel_registered_request(request_id: &str) -> CancellationTarget {
     let mut requests = REQUEST_LIFECYCLES.lock();
     match requests.get_mut(request_id) {
@@ -303,6 +327,47 @@ mod request_lifecycle_tests {
         assert!(registered_request_is_cancelled(request_id));
         drop(guard);
         assert!(!registered_request_is_cancelled(request_id));
+    }
+
+    #[test]
+    fn refused_turn_can_be_redelivered() {
+        // A turn whose thread could not be loaded never reaches the agent.
+        // Helix replays it under the same request_id, so ingress has to admit
+        // it again — otherwise the replay is dropped and the turn is stranded.
+        let request_id = "request-lifecycle-refused";
+        assert_eq!(register_queued_request(request_id, Some("thread-gone")), RequestAdmission::Accepted);
+        assert_eq!(register_queued_request(request_id, Some("thread-gone")), RequestAdmission::AlreadyActive);
+
+        abandon_queued_request(request_id);
+
+        assert_eq!(register_queued_request(request_id, None), RequestAdmission::Accepted);
+    }
+
+    #[test]
+    fn abandoning_leaves_a_running_turn_alone() {
+        // Only a turn that never started may be released. A live turn keeps its
+        // lane so a duplicate delivery still cannot push a second prompt into it.
+        let request_id = "request-lifecycle-abandon-running";
+        register_queued_request(request_id, None);
+        let (_, _guard) = start_registered_request(request_id, || ()).unwrap();
+
+        abandon_queued_request(request_id);
+
+        assert_eq!(register_queued_request(request_id, None), RequestAdmission::AlreadyActive);
+    }
+
+    #[test]
+    fn abandoning_preserves_a_cancellation_tombstone() {
+        // The tombstone must survive: start_registered_request consumes it to
+        // suppress a dispatch that cancellation already won the race against.
+        let request_id = "request-lifecycle-abandon-cancelled";
+        register_queued_request(request_id, None);
+        assert_eq!(cancel_registered_request(request_id), CancellationTarget::Queued);
+
+        abandon_queued_request(request_id);
+
+        assert!(registered_request_is_cancelled(request_id));
+        assert!(start_registered_request(request_id, || ()).is_none());
     }
 
     #[test]

--- a/crates/external_websocket_sync/src/thread_service.rs
+++ b/crates/external_websocket_sync/src/thread_service.rs
@@ -81,6 +81,11 @@ fn report_thread_open_failure(request: &ThreadOpenRequest, error: &anyhow::Error
     // agent panel. Sending it lets recoverMissingThread clear the stale pointer
     // so the next message forks a clean thread.
     let request_id = request.request_id.clone().unwrap_or_default();
+    // Nothing was dispatched for this turn, so let Helix redeliver it under the
+    // same request_id (see abandon_queued_request).
+    if !request_id.is_empty() {
+        crate::abandon_queued_request(&request_id);
+    }
     let event = SyncEvent::ThreadLoadError {
         acp_thread_id: request.acp_thread_id.clone(),
         request_id,
@@ -1805,6 +1810,13 @@ pub fn setup_thread_handler(
                                 "❌ [THREAD_SERVICE] Failed to load thread {} from agent: {}",
                                 existing_thread_id, e
                             );
+
+                            // This turn never reached the agent, so it is not
+                            // in flight. Release its ingress registration or the
+                            // recovery Helix runs next — which replays the turn
+                            // under the same request_id — is refused as a
+                            // duplicate and the interaction waits forever.
+                            crate::abandon_queued_request(&request.request_id);
 
                             let error_event = SyncEvent::ThreadLoadError {
                                 acp_thread_id: existing_thread_id.clone(),


### PR DESCRIPTION
## Problem

`register_queued_request` admits a turn at WebSocket ingress, and only `RequestLifecycleGuard::drop` clears it — but that guard is created when a prompt actually **starts**. A turn refused before that, because its thread could not be loaded, left a `Queued` entry that nothing ever dropped. Every later delivery of that same turn was then rejected:

```
🔁 [CALLBACK] Ignoring duplicate request_id=int_01m0dkgx… — this turn is already queued or running
```

Helix replays such a turn under its original `request_id` (`recoverMissingThread`), so the replay was silently discarded at ingress and the interaction waited forever.

Found while fixing DeepSeek Harness, whose ACP server declares no `loadSession` capability — after a Zed restart the load can *never* succeed, so the recovery replay was dropped every time and the task became unusable. The same guard also breaks the pre-existing missing-thread recovery whenever the first delivery arrived as a `chat_message` (an `open_thread`-triggered recovery escapes it only because `open_thread` never registers a request).

## Fix

Release the registration at both refusal points — the send path's load failure, and `report_thread_open_failure` — so the redelivery is admitted.

Only a `Queued` entry is dropped:

- a `Running` one belongs to a live turn (a duplicate never reaches these paths; ingress refuses it first), so the protection against pushing a second prompt into a live ACP session is untouched;
- a `Cancelled` one is a tombstone `start_registered_request` must still consume to suppress a dispatch that cancellation already won the race against.

## Testing

Three unit tests in `request_lifecycle_tests` cover redelivery after refusal, leaving a running turn alone, and preserving the cancellation tombstone. `cargo test -p external_websocket_sync --lib request_lifecycle` — 8 passed.

Verified end-to-end with this binary deployed into a live dsh spec-task sandbox: killed Zed mid-session, sent a follow-up, and the turn reached the agent (which answered from Helix's replayed context) instead of stranding. Before the change the identical scenario logged the duplicate rejection and the interaction never completed.

Paired with helixml/helix#3070, which pins this commit in `sandbox-versions.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)