### PR TITLE
Make headless smoke model deterministic

### DIFF
--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go
@@ -27,10 +27,9 @@
 //
 // Smoke mode (E2E_SMOKE=1) replaces the phase chain above with a single phase:
 // the agent is asked to read a file holding a magic number and echo it back. It
-// proves the whole path end-to-end — WebSocket sync, ACP turn, agent tool call,
-// streamed response, interaction completion — for the price of one short turn.
-// It exists so CI can gate `zed --headless` on every build without burning the
-// tokens the full suite costs.
+// proves the whole path end-to-end — WebSocket sync, agent turn, agent tool
+// call, streamed response, and interaction completion. A local deterministic
+// model drives the native Zed agent so CI does not depend on an external model.
 //
 // Plan mode (E2E_PLAN=1) uses a deterministic ACP agent for two turns. The
 // first publishes a plan and the second publishes no plan. It verifies that a
@@ -2900,6 +2899,9 @@ func main() {
 		// Delegate to the REAL production handler
 		srv.ExternalAgentSyncHandler()(w, r)
 	})
+	if smokeMode {
+		http.HandleFunc("/v1/chat/completions", smokeChatCompletionHandler)
+	}
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/smoke_model.go
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/smoke_model.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+)
+
+type smokeChatCompletionRequest struct {
+	Model    string `json:"model"`
+	Messages []struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	} `json:"messages"`
+	Stream bool `json:"stream"`
+	Tools  []struct {
+		Function struct {
+			Name string `json:"name"`
+		} `json:"function"`
+	} `json:"tools"`
+}
+
+type smokeChatCompletionEvent struct {
+	Choices []smokeChatCompletionChoice `json:"choices"`
+	Usage   *smokeChatCompletionUsage   `json:"usage"`
+}
+
+type smokeChatCompletionUsage struct{}
+
+type smokeChatCompletionChoice struct {
+	Index        int                       `json:"index"`
+	Delta        *smokeChatCompletionDelta `json:"delta"`
+	FinishReason *string                   `json:"finish_reason,omitempty"`
+}
+
+type smokeChatCompletionDelta struct {
+	Role      string                        `json:"role,omitempty"`
+	Content   string                        `json:"content,omitempty"`
+	ToolCalls []smokeChatCompletionToolCall `json:"tool_calls,omitempty"`
+}
+
+type smokeChatCompletionToolCall struct {
+	Index    int                                `json:"index"`
+	ID       string                             `json:"id"`
+	Function smokeChatCompletionToolCallDetails `json:"function"`
+}
+
+type smokeChatCompletionToolCallDetails struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+func smokeChatCompletionHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method must be POST", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var request smokeChatCompletionRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		http.Error(w, "invalid JSON request", http.StatusBadRequest)
+		return
+	}
+	if request.Model != "e2e-smoke-model" {
+		http.Error(w, "unexpected model", http.StatusBadRequest)
+		return
+	}
+	if !request.Stream {
+		http.Error(w, "streaming is required", http.StatusBadRequest)
+		return
+	}
+
+	hasReadFileTool := false
+	for _, tool := range request.Tools {
+		if tool.Function.Name == "read_file" {
+			hasReadFileTool = true
+			break
+		}
+	}
+	if !hasReadFileTool {
+		http.Error(w, "read_file tool was not provided", http.StatusBadRequest)
+		return
+	}
+
+	var toolResult json.RawMessage
+	for _, message := range request.Messages {
+		if message.Role == "tool" {
+			toolResult = message.Content
+		}
+	}
+
+	if toolResult == nil {
+		arguments, err := json.Marshal(map[string]string{"path": smokeMagicFile})
+		if err != nil {
+			http.Error(w, "failed to encode tool arguments", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		finishReason := "tool_calls"
+		writeSmokeSSE(w,
+			smokeChatCompletionEvent{Choices: []smokeChatCompletionChoice{{
+				Index: 0,
+				Delta: &smokeChatCompletionDelta{
+					Role: "assistant",
+					ToolCalls: []smokeChatCompletionToolCall{{
+						Index: 0,
+						ID:    "call_e2e_read_file",
+						Function: smokeChatCompletionToolCallDetails{
+							Name:      "read_file",
+							Arguments: string(arguments),
+						},
+					}},
+				},
+			}}},
+			smokeChatCompletionEvent{Choices: []smokeChatCompletionChoice{{
+				Index:        0,
+				FinishReason: &finishReason,
+			}}},
+		)
+		return
+	}
+
+	if !strings.Contains(string(toolResult), smokeMagicValue) {
+		http.Error(w, "read_file result did not contain the magic value", http.StatusBadRequest)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	finishReason := "stop"
+	writeSmokeSSE(w,
+		smokeChatCompletionEvent{Choices: []smokeChatCompletionChoice{{
+			Index: 0,
+			Delta: &smokeChatCompletionDelta{
+				Role:    "assistant",
+				Content: smokeMagicValue,
+			},
+		}}},
+		smokeChatCompletionEvent{Choices: []smokeChatCompletionChoice{{
+			Index:        0,
+			FinishReason: &finishReason,
+		}}},
+	)
+}
+
+func writeSmokeSSE(w http.ResponseWriter, events ...smokeChatCompletionEvent) {
+	for _, event := range events {
+		encoded, err := json.Marshal(event)
+		if err != nil {
+			log.Printf("[smoke-model] Failed to encode event: %v", err)
+			return
+		}
+		if _, err := fmt.Fprintf(w, "data: %s\n\n", encoded); err != nil {
+			log.Printf("[smoke-model] Failed to write event: %v", err)
+			return
+		}
+	}
+	if _, err := fmt.Fprint(w, "data: [DONE]\n\n"); err != nil {
+		log.Printf("[smoke-model] Failed to write stream terminator: %v", err)
+	}
+}

--- a/crates/external_websocket_sync/e2e-test/helix-ws-test-server/smoke_model_test.go
+++ b/crates/external_websocket_sync/e2e-test/helix-ws-test-server/smoke_model_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func smokeRequest(t *testing.T, messages []map[string]interface{}) *http.Request {
+	t.Helper()
+	body, err := json.Marshal(map[string]interface{}{
+		"model":    "e2e-smoke-model",
+		"messages": messages,
+		"stream":   true,
+		"tools": []interface{}{map[string]interface{}{
+			"type": "function",
+			"function": map[string]interface{}{
+				"name": "read_file",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	return httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+}
+
+func smokeEvents(t *testing.T, body string) []map[string]interface{} {
+	t.Helper()
+	var events []map[string]interface{}
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") || line == "data: [DONE]" {
+			continue
+		}
+		var event map[string]interface{}
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &event); err != nil {
+			t.Fatalf("decode SSE event: %v", err)
+		}
+		events = append(events, event)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan SSE response: %v", err)
+	}
+	return events
+}
+
+func TestSmokeChatCompletionRequestsReadFile(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	smokeChatCompletionHandler(recorder, smokeRequest(t, []map[string]interface{}{
+		{"role": "user", "content": "read the fixture"},
+	}))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if contentType := recorder.Header().Get("Content-Type"); contentType != "text/event-stream" {
+		t.Fatalf("Content-Type = %q", contentType)
+	}
+	events := smokeEvents(t, recorder.Body.String())
+	if len(events) != 2 {
+		t.Fatalf("got %d events, body = %s", len(events), recorder.Body.String())
+	}
+	encoded, err := json.Marshal(events[0])
+	if err != nil {
+		t.Fatalf("marshal response event: %v", err)
+	}
+	response := string(encoded)
+	for _, expected := range []string{"call_e2e_read_file", "read_file", smokeMagicFile} {
+		if !strings.Contains(response, expected) {
+			t.Errorf("first response event does not contain %q: %s", expected, response)
+		}
+	}
+}
+
+func TestSmokeChatCompletionReturnsToolResult(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	smokeChatCompletionHandler(recorder, smokeRequest(t, []map[string]interface{}{
+		{"role": "user", "content": "read the fixture"},
+		{"role": "tool", "content": "1→4242"},
+	}))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	events := smokeEvents(t, recorder.Body.String())
+	if len(events) != 2 {
+		t.Fatalf("got %d events, body = %s", len(events), recorder.Body.String())
+	}
+	encoded, err := json.Marshal(events[0])
+	if err != nil {
+		t.Fatalf("marshal response event: %v", err)
+	}
+	if !strings.Contains(string(encoded), smokeMagicValue) {
+		t.Fatalf("response does not contain %q: %s", smokeMagicValue, encoded)
+	}
+}
+
+func TestSmokeChatCompletionRejectsWrongToolResult(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	smokeChatCompletionHandler(recorder, smokeRequest(t, []map[string]interface{}{
+		{"role": "tool", "content": "wrong value"},
+	}))
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+}

--- a/crates/external_websocket_sync/e2e-test/run_e2e.sh
+++ b/crates/external_websocket_sync/e2e-test/run_e2e.sh
@@ -182,8 +182,8 @@ echo ""
 
 # ---- Smoke mode ----
 # E2E_SMOKE=1 runs a single tool-call phase instead of the full suite: the agent
-# reads magic-number.txt and echoes the value. Cheap enough to gate every CI
-# build on. The value is not in the prompt, so it can only come from a tool call.
+# reads magic-number.txt and echoes the value. A deterministic local model drives
+# the native agent, so this can gate every CI build without external credentials.
 export E2E_SMOKE="${E2E_SMOKE:-0}"
 export E2E_PLAN="${E2E_PLAN:-0}"
 if [ "$E2E_SMOKE" = "1" ]; then
@@ -213,6 +213,14 @@ fi
 MOCK_PORT=$(cat "$MOCK_PORT_FILE")
 echo "[mock-server] Running on port $MOCK_PORT"
 echo ""
+
+if [ "$E2E_SMOKE" = "1" ]; then
+    export E2E_MODEL_PROVIDER=openai
+    export E2E_MODEL=e2e-smoke-model
+    export OPENAI_API_KEY=e2e-smoke-key
+    export OPENAI_BASE_URL="http://127.0.0.1:${MOCK_PORT}/v1"
+    echo "[setup] Smoke mode: using deterministic local model at $OPENAI_BASE_URL"
+fi
 
 # ---- Configure Zed via environment variables ----
 # ExternalSyncSettings reads from env vars, not settings.json

--- a/portingguide.md
+++ b/portingguide.md
@@ -483,16 +483,15 @@ panel is the source of those in headful mode and we don't track them here).
 
 ### Smoke mode (`E2E_SMOKE=1`) — the CI gate
 
-The full suite costs a lot of tokens, which is why it was gated to main + tags
-and headless was never gated at all. `E2E_SMOKE=1` replaces the phase chain with
-a single phase: the agent reads `magic-number.txt` and replies with the value.
-One short turn covers WebSocket sync, worktree setup, an agent tool call,
-streaming and interaction completion. The value never appears in the prompt, so
-only a real tool call can produce it.
+`E2E_SMOKE=1` replaces the phase chain with a single phase: the native Zed agent
+reads `magic-number.txt` and replies with the value. A deterministic local
+OpenAI-compatible server requests the `read_file` tool, validates its result,
+and returns the value. This covers WebSocket sync, worktree setup, a native
+agent tool call, streaming, and interaction completion without an external
+model dependency.
 
 ```bash
-E2E_HEADLESS=1 E2E_SMOKE=1 E2E_AGENTS=zed-agent \
-  E2E_MODEL_PROVIDER=openai E2E_MODEL=gpt-5.6-luna ./run_docker_e2e.sh
+E2E_HEADLESS=1 E2E_SMOKE=1 E2E_AGENTS=zed-agent ./run_docker_e2e.sh
 ```
 
 Knobs (all optional, all default to today's behaviour):
@@ -501,8 +500,8 @@ Knobs (all optional, all default to today's behaviour):
 |-----|---------|---------|
 | `E2E_SMOKE` | `0` | Single tool-call phase instead of the full suite |
 | `E2E_SMOKE_FILE` | `<project>/magic-number.txt` | Absolute path the agent is told to read |
-| `E2E_MODEL_PROVIDER` | `anthropic` | Native-agent provider (`openai` emits an `available_models` entry) |
-| `E2E_MODEL` | `claude-sonnet-4-6` | Native-agent model id |
+| `E2E_MODEL_PROVIDER` | `anthropic` | Native-agent provider outside smoke mode (`openai` emits an `available_models` entry) |
+| `E2E_MODEL` | `claude-sonnet-4-6` | Native-agent model id outside smoke mode |
 | `E2E_REASONING_EFFORT` | `none` | OpenAI only. Must stay `none`: `/v1/chat/completions` rejects any other effort when the request carries function tools |
 | `E2E_CODEX_MODEL` | `gpt-5.6-terra` | codex-acp model id, `model[effort]` form |
 


### PR DESCRIPTION
## What changed

- add a local OpenAI-compatible streaming fixture for smoke mode
- make the fixture request the native read_file tool and reject an incorrect tool result
- configure smoke mode to use the local model automatically
- add handler tests and update the E2E documentation

## Why

The always-on Helix CI smoke gate depended on a live model endpoint. Repeated endpoint-not-found and HTTP 502 responses failed unrelated builds even though the deterministic headless protocol lanes passed. The local fixture preserves native Zed agent and tool-call coverage while removing provider availability and model behavior from the assertion.

Helix pin: https://github.com/helixml/helix/pull/3137

## Verification

- go test ./... -count=1
- real containerized headless smoke passed 6/6 runs
- each run exercised native read_file, streamed 4242, completed the interaction, and passed production-handler store validation
- bash -n crates/external_websocket_sync/e2e-test/run_e2e.sh

## Suggested .rules additions

- CI tests that assert product or protocol behavior must not depend on live model availability; use a deterministic local model fixture and keep provider health checks in a separate non-gating lane.

Release Notes:

- N/A